### PR TITLE
fix(liepin): unbreak collect pipeline + add real city filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,89 @@ end-to-end against live HR inboxes (5/5 delivered on a real batch).
     assert real `Input.dispatchMouseEvent` was emitted.
   - New evaluate sequence: risk-check + locate + 3 polling evaluates.
 
+## [Unreleased — Liepin beta pipeline] — 2026-06-22
+
+The Liepin vertical chain was returning 0 jobs on `liepin collect` and
+silently mis-attribute cities. Six issues fixed, all verified end-to-end
+with a real 2/2 delivered batch against 京东物流 HR.
+
+### Fixed
+
+#### 1. Wrong search URL path (0 jobs returned)
+- **Symptom**: `liepin collect` always returned 0 jobs.
+- **Cause**: `build_liepin_search_url` used `/zhaopin/` path. On logged-in
+  sessions, Liepin serves an SEO landing page there showing "非常抱歉！暂时
+  没有合适的职位". The real search endpoint is `/sojob/`.
+- **Fix**: switched to `/sojob/` path with `city=` param (the older `dq=`
+  param is silently dropped by Liepin's redirect).
+
+#### 2. Parser overrode real city with requested city
+- **Symptom**: every parsed Job had `city="北京"` even when the card text
+  clearly said "上海-黄浦区" or "沈阳-浑南区".
+- **Cause**: `parse_liepin_job` used `city_name or _first(raw, "city", ...)`
+  — the user-requested city won over the card's actual city.
+- **Fix**: reversed to `_first(raw, ...) or city_name`. Card's own city
+  field wins; requested city is only a fallback.
+
+#### 3. Snapshot selector rejected real `<a>` job cards as "missingIdentity"
+- **Symptom**: 109 of 190 candidate elements rejected, only 8-10 cards
+  parsed per page.
+- **Cause**: selector looked for `el.querySelector('a[href*="/job/"]')`
+  (descendant `<a>`). Liepin wraps job titles in `<a href="/job/XXX.shtml">`
+  directly — the candidate IS the `<a>`, no descendant `<a>` exists.
+- **Fix**: when the candidate element is itself an `<a>` with `/job/` href,
+  accept it as the link.
+
+#### 4. City filter not actually applied
+- **Symptom**: `--city 北京` returned jobs from 沈阳, 上海, 乌鲁木齐.
+- **Cause**: Liepin's sojob endpoint ignores URL city params server-side
+  (all of `city=`, `cityCode=`, `dq=` return the same mixed-city results).
+- **Fix**: added `_city_matches` post-filter in Python on the parsed
+  `Job.city` field. To compensate for filtered-out cards, the snapshot
+  fetch limit is doubled when a city filter is active.
+
+#### 5. Pagination dedup treated same job on different pages as different
+- **Symptom**: `--pages 3` returned 16 jobs where 8 were duplicates of
+  the other 8.
+- **Cause**: `_job_dedupe_key` used the full URL as key. Liepin decorates
+  the same job's URL with different per-page query params (`d_posi=`,
+  `skId=`, `ckId=`, `curPage=`, `index=`, …), so the same `/job/1983458373.shtml`
+  had a different URL string on page 1 vs page 2.
+- **Fix**: extract `/job/<id>.shtml` from the URL and use `job:<id>` as
+  the dedup key. Falls back to full URL only if regex doesn't match.
+
+#### 6. Snapshot city extraction missed non-whitelisted cities
+- **Symptom**: jobs in 沈阳, 乌鲁木齐, 南京 (any city not in the hardcoded
+  whitelist) were extracted with empty `cityName`, which then fell back
+  to the user-requested city (Bug #2 above), making the city filter
+  incorrectly include them.
+- **Cause**: selector used `/北京|上海|深圳|.../.test(line)` — whitelist
+  of ~20 cities.
+- **Fix**: prefer the `【城市-区域】` bracketed pattern Liepin uses on
+  every card (catches any Chinese city). Fall back to an expanded
+  whitelist (added 沈阳, 乌鲁木齐, 济南, 哈尔滨, 长春, 昆明, 南宁, 福州,
+  石家庄, 太原, 贵阳, 兰州, 海口, 南昌, 无锡, 温州, 珠海, 中山, 惠州).
+
+### Documentation
+
+- `LiepinApplySender` docstring now explicitly documents that:
+  - Liepin has no Boss-style greeting chat flow.
+  - The only contact mechanism is "立即投递" (submit resume).
+  - Generated greetings are handoff-only (used by `liepin apply open`
+    for human copy-paste), NOT auto-sent by `apply send`.
+  - The `fill_liepin_message` step reporting `editor_not_found` on
+    every healthy Liepin job page is **expected behavior, not a bug**.
+- `_liepin_apply_click_entry_script` docstring documents why 立即投递
+  variants come first in the label list.
+
+### Tests
+
+- Updated `test_liepin_search_url_encodes_query_and_city` for new URL
+  contract (`/sojob/`, `city=`, `curPage=`).
+- Updated `test_liepin_live_read_only_collector_*` and
+  `test_liepin_session_check_reports_login_required` to assert the new
+  `/sojob/` URL.
+
 ## [0.2.1] — 2026-06-15
 
 ### Changed

--- a/src/jobagent/platforms/liepin/apply.py
+++ b/src/jobagent/platforms/liepin/apply.py
@@ -171,7 +171,28 @@ class LiepinApplyOpener:
 
 
 class LiepinApplySender:
-    """Send/apply to Liepin jobs with platform-owned page automation."""
+    """Send/apply to Liepin jobs with platform-owned page automation.
+
+    Liepin UX differs fundamentally from Boss直聘:
+      - **No greeting-based chat flow.** Liepin doesn't have a Boss-style
+        "打招呼 → 进聊天 → 发招呼语" loop. The only contact mechanism on
+        a Liepin job page is "立即投递" (submit resume). The "聊一聊"
+        button (when present) requires a pre-existing relationship and
+        isn't an outbound greeting channel.
+      - **Greeting is handoff-only.** ``liepin greet preview`` generates
+        a personalized greeting, but it is NOT auto-sent by this sender.
+        The greeting is emitted into the JSON ``handoff`` field for the
+        ``liepin apply open`` flow, where the human user manually copies
+        it into whatever channel they choose (manual 聊一聊, email, etc.).
+      - **This sender does ONE thing: click 立即投递 to submit the
+        resume that's bound to the user's Liepin account.** No message
+        is sent. The ``message`` parameter is accepted for API symmetry
+        with Boss but is not delivered to the recruiter.
+
+    The ``fill_liepin_message`` step in ``_drive_dialog`` will report
+    ``editor_not_found`` on every healthy Liepin job page — that is
+    expected behavior, not a bug.
+    """
 
     def __init__(
         self,
@@ -437,6 +458,14 @@ def _liepin_apply_inspect_script() -> str:
 
 
 def _liepin_apply_click_entry_script() -> str:
+    """Return JS that clicks the primary apply/contact entry button.
+
+    Label order matters: 立即投递 variants come FIRST because Liepin only
+    supports resume submission (no Boss-style greeting chat). 聊一聊 /
+    立即沟通 are listed only as last-resort fallbacks for edge cases
+    where a job page shows only a chat entry (rare); they are NOT used
+    for sending greetings automatically.
+    """
     return r"""
     (function(){
       const labels = [

--- a/src/jobagent/platforms/liepin/collect.py
+++ b/src/jobagent/platforms/liepin/collect.py
@@ -18,12 +18,21 @@ from .selectors import build_liepin_snapshot_script
 
 
 def build_liepin_search_url(query: str, city: str = "", page: int = 1) -> str:
-    """Build a human-search URL for the live read-only spike."""
-    url = f"https://www.liepin.com/zhaopin/?key={quote(query)}"
+    """Build a human-search URL for the live read-only spike.
+
+    Path: /sojob/ (not /zhaopin/).
+      The /zhaopin/ path is a SEO landing page that returns 0 results when
+      accessed under a logged-in session (Liepin shows "非常抱歉！暂时没有
+      合适的职位"). /sojob/ is the real search endpoint.
+
+    City param: &city=<name>.
+      Older formats (&dq=<name>) get silently dropped by Liepin's redirect.
+    """
+    url = f"https://www.liepin.com/sojob/?key={quote(query)}"
     if city:
-        url += f"&dq={quote(city)}"
+        url += f"&city={quote(city)}"
     if page > 1:
-        url += f"&currentPage={page}"
+        url += f"&curPage={page}"
     return url
 
 
@@ -84,7 +93,14 @@ class LiepinReadOnlyCollector:
         pages: int = 1,
         page_delay: float = 3.0,
     ) -> LiepinCollectResult:
-        """Open one or more Liepin search pages and extract visible job cards."""
+        """Open one or more Liepin search pages and extract visible job cards.
+
+        City filtering: Liepin's sojob endpoint silently ignores URL city
+        params (city=, cityCode=, dq= all return the same mixed-city results).
+        We apply a Python-side post-filter on the parsed ``city`` field instead.
+        To compensate for cards dropped by the filter, we request more cards
+        per page from the snapshot script (2× the user's limit).
+        """
         if not query:
             raise ValueError("query is required for live Liepin read-only collect")
 
@@ -116,7 +132,10 @@ class LiepinReadOnlyCollector:
                 )
 
             remaining = max(1, limit - len(jobs))
-            snapshot = self._extract_snapshot(limit=remaining)
+            # When city filter is active, fetch 2× more cards per page to
+            # compensate for non-matching ones that will be filtered out.
+            fetch_limit = remaining * 2 if city else remaining
+            snapshot = self._extract_snapshot(limit=fetch_limit)
             snapshot["page"] = current_page
             snapshot["requestedUrl"] = url
             snapshots.append(snapshot)
@@ -144,6 +163,9 @@ class LiepinReadOnlyCollector:
                 if not isinstance(card, dict):
                     continue
                 job = parse_liepin_job(card, city_name=city)
+                # Apply city post-filter (Liepin URL params don't filter server-side)
+                if not _city_matches(job.city, city):
+                    continue
                 key = _job_dedupe_key(job, card)
                 if key in seen:
                     continue
@@ -200,12 +222,48 @@ def _combined_snapshot(
 
 
 def _job_dedupe_key(job: Job, raw: dict[str, Any]) -> str:
+    """Build a stable dedup key for a Liepin job.
+
+    Priority:
+      1. Explicit jobId attribute on the card (rare on current Liepin DOM).
+      2. Job ID extracted from URL path (/job/<id>.shtml). This is critical
+         because Liepin decorates the same job's URL with different query
+         params per page (d_posi, skId, fkId, ckId, curPage, index, …).
+         Using the full URL as key treated the same job on page 1 and page 2
+         as different, inflating counts and defeating pagination dedup.
+      3. Full URL fallback (last resort).
+      4. Name+company+city text fallback when no URL at all.
+    """
+    import re
+
     job_id = liepin_job_id(raw)
     if job_id:
         return f"id:{job_id}"
     if job.url:
+        m = re.search(r"/job/(\d+)\.shtml", job.url)
+        if m:
+            return f"job:{m.group(1)}"
         return f"url:{job.url}"
     return f"text:{job.name}|{job.company}|{job.city}"
+
+
+def _city_matches(job_city: str, requested_city: str) -> bool:
+    """Check whether a job's parsed city matches the user-requested city.
+
+    Liepin's sojob endpoint ignores URL city params server-side, so the
+    search results are a mix of cities. This post-filter is the only
+    reliable way to apply a city filter.
+
+    Matches when:
+      - No requested_city (filter disabled), OR
+      - job_city starts with requested_city (handles "北京" and "北京-朝阳区"), OR
+      - Either side is empty (permissive — better to over-include than drop).
+    """
+    if not requested_city:
+        return True
+    if not job_city:
+        return True  # don't drop cards with missing city field
+    return job_city.split("-")[0].strip() == requested_city.split("-")[0].strip()
 
 
 def _snapshot_failure(snapshot: dict[str, Any]) -> str:

--- a/src/jobagent/platforms/liepin/parser.py
+++ b/src/jobagent/platforms/liepin/parser.py
@@ -35,12 +35,21 @@ def liepin_job_id(raw: dict[str, Any]) -> str:
 
 
 def parse_liepin_job(raw: dict[str, Any], city_name: str = "") -> Job:
-    """Parse a Liepin job row into the shared Job model."""
+    """Parse a Liepin job row into the shared Job model.
+
+    ``city_name`` is the user-requested city (e.g., "北京"). It is used ONLY as
+    a fallback when the card itself doesn't expose a city — Liepin's sojob
+    endpoint ignores URL city params server-side, so cards frequently come
+    from mixed cities. The parser prefers the card's own city field so the
+    caller can post-filter accurately.
+    """
     job_id = liepin_job_id(raw)
     company = _first(raw, "companyName", "company", "compName", "company_name")
     title = _first(raw, "title", "jobTitle", "jobName", "positionName")
     salary = _first(raw, "salary", "salaryText", "salaryDesc", "salaryLabel")
-    city = city_name or _first(raw, "city", "cityName", "dq")
+    # Card's own city wins over the user-requested city_name. The requested
+    # city is only a fallback for cards that don't expose any location field.
+    city = _first(raw, "city", "cityName", "dq") or city_name
     area = _join_non_empty([
         _first(raw, "district", "districtName"),
         _first(raw, "businessArea", "businessDistrict"),

--- a/src/jobagent/platforms/liepin/selectors.py
+++ b/src/jobagent/platforms/liepin/selectors.py
@@ -61,7 +61,16 @@ def build_liepin_snapshot_script(limit: int = 20) -> str:
           rejected.weakSignal += 1;
           continue;
         }}
-        const link = el.querySelector('a[href*="/job/"], a[href*="liepin.com/job"]');
+        // Identity: prefer a child <a> with /job/ href; also accept the
+        // candidate itself when it IS the <a> (Liepin wraps job titles in
+        // <a href="/job/XXX.shtml"> directly, with no inner <a>).
+        let link = el.querySelector('a[href*="/job/"], a[href*="liepin.com/job"]');
+        if (!link && el.tagName === 'A') {{
+          const selfHref = el.getAttribute('href') || '';
+          if (selfHref.indexOf('/job/') >= 0 || selfHref.indexOf('liepin.com/job') >= 0) {{
+            link = el;
+          }}
+        }}
         const url = link ? absUrl(link.getAttribute('href') || '') : '';
         const id = el.getAttribute('data-job-id') || el.getAttribute('data-id') || '';
         if (!url && !id) {{
@@ -81,7 +90,20 @@ def build_liepin_snapshot_script(limit: int = 20) -> str:
           continue;
         }}
         const salaryIndex = lines.findIndex(x => /k|薪|万|元/i.test(x));
-        const cityIndex = lines.findIndex(x => /北京|上海|深圳|广州|杭州|成都|南京|苏州|武汉|西安|天津|重庆|大连|厦门|青岛|长沙|郑州|合肥|佛山|东莞|宁波/.test(x));
+        // City extraction (two strategies):
+        //   1. Prefer the 【城市-区域】 bracketed pattern Liepin uses on job
+        //      cards ("【沈阳-浑南区】", "【上海-黄浦区】", etc.) — this catches
+        //      every Chinese city, not just a whitelist.
+        //   2. Fall back to a major-city whitelist for cards without brackets.
+        let cityIndex = -1;
+        for (let i = 0; i < lines.length; i++) {{
+          if (/^[【\\[]?[\\u4e00-\\u9fa5]{2,8}-[\\u4e00-\\u9fa5]{2,8}[】\\]]?$/.test(lines[i])) {{
+            cityIndex = i; break;
+          }}
+        }}
+        if (cityIndex < 0) {{
+          cityIndex = lines.findIndex(x => /北京|上海|深圳|广州|杭州|成都|南京|苏州|武汉|西安|天津|重庆|大连|厦门|青岛|长沙|郑州|合肥|佛山|东莞|宁波|沈阳|乌鲁木齐|济南|哈尔滨|长春|昆明|南宁|福州|石家庄|太原|贵阳|兰州|海口|南昌|无锡|温州|珠海|中山|惠州/.test(x));
+        }}
         const experienceIndex = lines.findIndex(x => /经验|年/.test(x));
         const degreeIndex = lines.findIndex(x => /本科|硕士|博士|大专|学历|统招/.test(x));
         const salary = salaryIndex >= 0 ? lines[salaryIndex] : '';

--- a/tests/test_liepin_platform_boundary.py
+++ b/tests/test_liepin_platform_boundary.py
@@ -397,11 +397,13 @@ def test_liepin_search_url_encodes_query_and_city():
     url = build_liepin_search_url("AI产品", "深圳")
     page_url = build_liepin_search_url("AI产品", "深圳", page=3)
 
-    assert url.startswith("https://www.liepin.com/zhaopin/?")
+    # URL contract: /sojob/ path (not /zhaopin/ which returns 0 results logged-in),
+    # city= param (not dq= which Liepin silently drops).
+    assert url.startswith("https://www.liepin.com/sojob/?")
     assert "key=AI" in url
-    assert "dq=" in url
-    assert "currentPage=" not in url
-    assert "currentPage=3" in page_url
+    assert "city=" in url
+    assert "curPage=" not in url
+    assert "curPage=3" in page_url
 
 
 def test_liepin_live_read_only_collector_uses_visible_cards_only():
@@ -417,7 +419,7 @@ def test_liepin_live_read_only_collector_uses_visible_cards_only():
     assert result.mode == "live_read_only"
     assert result.jobs[0].platform == "liepin"
     assert result.jobs[0].name == "AI商业化产品经理"
-    assert driver.calls[0].startswith("open:https://www.liepin.com/zhaopin/")
+    assert driver.calls[0].startswith("open:https://www.liepin.com/sojob/")
     assert driver.calls[-1] == "extract_snapshot"
     assert LIEPIN_SELECTOR_VERSION in driver.last_js
 
@@ -439,7 +441,7 @@ def test_liepin_live_read_only_collector_fetches_pages_and_dedupes():
     assert result.pages == 2
     assert [job.name for job in result.jobs] == ["AI商业化产品经理", "AI Agent 产品负责人"]
     assert len(driver.urls) == 2
-    assert "currentPage=2" in driver.urls[1]
+    assert "curPage=2" in driver.urls[1]
     assert result.snapshot["pages"][0]["page"] == 1
     assert result.snapshot["pages"][1]["page"] == 2
 
@@ -492,7 +494,7 @@ def test_liepin_session_check_reports_login_required():
     assert status.logged_in is False
     assert status.login_required is True
     assert status.to_dict()["next_suggested"] == "jobagent liepin login"
-    assert driver.calls[0].startswith("open:https://www.liepin.com/zhaopin/")
+    assert driver.calls[0].startswith("open:https://www.liepin.com/sojob/")
     assert driver.calls[-1] == "inspect_session"
 
 


### PR DESCRIPTION
## Summary

The Liepin vertical chain was returning **0 jobs** on `liepin collect` and silently mis-attributing cities. Six issues fixed, verified end-to-end with a real 2/2 delivered batch against 京东物流 HR.

📄 **Full changelog**: [`CHANGELOG.md` — Liepin beta pipeline section](https://github.com/jiyangnan/AgentMesh-JobAgent/blob/fix/liepin-collect-and-city-filter/CHANGELOG.md#unreleased--liepin-beta-pipeline--2026-06-22)

## Problems → Fixes

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | `liepin collect` always returns 0 jobs | URL path `/zhaopin/` serves SEO landing page on logged-in sessions | Switched to `/sojob/` (real search endpoint); `dq=` → `city=` |
| 2 | Every parsed Job has `city="北京"` even for 上海 jobs | `parse_liepin_job` used `city_name or _first(raw, "city")` — requested city won | Reversed: card's own city wins, requested city is fallback |
| 3 | 109/190 cards rejected as "missingIdentity" | Selector looked for descendant `<a>`. Liepin wraps job titles in `<a>` directly | Accept candidate itself when it IS an `<a>` with `/job/` href |
| 4 | `--city 北京` returns jobs from 沈阳/上海 | Liepin sojob endpoint ignores all URL city params server-side | Python-side `_city_matches` post-filter on parsed `Job.city` |
| 5 | `--pages 3` returns 16 jobs where 8 are duplicates | URL dedup used full URL string; Liepin decorates same job with different per-page params | Extract `/job/<id>.shtml` → `job:<id>` as dedup key |
| 6 | Jobs in 沈阳/乌鲁木齐/etc. extracted with empty city | Hardcoded whitelist missed them; empty city fell back to requested city | Prefer `【城市-区域】` bracket pattern + expanded whitelist |

## Documentation — Liepin UX clarification

Added explicit docstrings to prevent a class of future bugs:

- **`LiepinApplySender`**: Liepin has **no Boss-style greeting chat flow**. Only contact mechanism is "立即投递" (submit resume). Generated greetings are handoff-only (used by `liepin apply open` for human copy-paste), NOT auto-sent by `apply send`. The `fill_liepin_message` step reporting `editor_not_found` on every healthy Liepin job page is **expected behavior, not a bug**.
- **`_liepin_apply_click_entry_script`**: documents why 立即投递 variants come first in label list.

## Test plan

- [x] **Live `liepin collect` 北京 AI产品经理 3 pages** → 北京 jobs only (previously 0, previously mixed cities)
- [x] **Live `liepin rank` + `greet preview`** → 2/2 jobs ranked + greeted
- [x] **Live `liepin apply send --confirm-submit`** → 2/2 delivered to 京东物流 HR
- [x] **Unit tests** — 191/192 passing. Updated 4 liepin tests for new URL contract (`/sojob/`, `city=`, `curPage=`).
- [ ] **Pre-existing failure** — `test_liepin_doctor_with_cloud_reports_missing_license` fails on `origin/main` too (unrelated `cloud_license_configured` KeyError). Out of scope for this PR.

## Files Changed

```
CHANGELOG.md                                  | 83 +++++++++++++++++
src/jobagent/platforms/liepin/apply.py        |  22 +++-
src/jobagent/platforms/liepin/collect.py      |  47 ++++++--
src/jobagent/platforms/liepin/parser.py       |  13 ++-
src/jobagent/platforms/liepin/selectors.py    |  20 +++-
tests/test_liepin_platform_boundary.py        |  10 +-
6 files changed, 221 insertions(+), 18 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)