### PR TITLE
fix(zhilian): apply real city filter + dedup by job id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,41 @@ with a real 2/2 delivered batch against 京东物流 HR.
   `test_liepin_session_check_reports_login_required` to assert the new
   `/sojob/` URL.
 
+## [Unreleased — Zhilian beta pipeline] — 2026-06-22
+
+The Zhilian vertical chain worked end-to-end out of the box (20 jobs →
+5/5 delivered), but `--city` filter was silently ignored: 20 jobs came
+back spread across 12 cities (only 4 in 北京). Two issues fixed.
+
+### Fixed
+
+#### 1. City filter not actually applied
+- **Symptom**: `zhilian collect --city 北京` returned jobs from 上海/合肥/
+  青岛/厦门/石家庄/重庆/保定/长春/福州/佛山/广州 — only 4 of 20 were in 北京.
+- **Cause**: Zhilian's `sou.zhaopin.com` endpoint accepts the `jl=` URL
+  param but doesn't filter results server-side. Same pattern as Liepin.
+- **Fix**: added `_city_matches` Python post-filter on parsed `Job.city`.
+  Handles Zhilian's `·` separator ("北京·朝阳区") in addition to `-`.
+  Doubled snapshot fetch limit when city filter is active.
+
+#### 2. Pagination dedup used full URL string
+- **Symptom (latent)**: same job on different pages would have different
+  URLs (Zhilian decorates with `refcode=`, `srccode=`, `preactionid=`),
+  so URL-based dedup would treat them as different.
+- **Fix**: extract `/jobdetail/<ALNUM>.htm` from URL, use `job:<id>` as
+  dedup key. Falls back to full URL only if regex doesn't match.
+
+### Documentation
+
+- `ZhilianApplySender` docstring explicitly documents that:
+  - Zhilian has no Boss-style greeting chat flow.
+  - The only contact mechanism is "立即投递" (submit resume).
+  - Generated greetings are handoff-only (used by `zhilian apply open`
+    for human copy-paste), NOT auto-sent by `apply send`.
+  - The `zhilian_greeting_not_supported` step reporting
+    `zhilian_resume_submit_has_no_message_editor` on every healthy
+    Zhilian job page is **expected behavior, not a bug**.
+
 ## [0.2.1] — 2026-06-15
 
 ### Changed

--- a/src/jobagent/platforms/zhilian/apply.py
+++ b/src/jobagent/platforms/zhilian/apply.py
@@ -144,6 +144,27 @@ class ZhilianApplyOpener:
 
 
 class ZhilianApplySender:
+    """Submit resumes to Zhilian jobs via "立即投递".
+
+    Zhilian UX differs fundamentally from Boss直聘:
+      - **No greeting-based chat flow.** Zhilian's contact mechanism on a job
+        page is "立即投递" (submit the resume bound to the user's Zhilian
+        account). The "立即沟通" button exists but opens a separate IM
+        channel that doesn't accept an outbound greeting on first contact.
+      - **Greeting is handoff-only.** ``zhilian greet preview`` generates a
+        personalized greeting, but it is NOT auto-sent by this sender. The
+        greeting is emitted into the JSON ``handoff`` field for the
+        ``zhilian apply open`` flow, where the human user manually copies
+        it into whatever channel they choose.
+      - **This sender does ONE thing: click 立即投递 to submit the resume.**
+        The ``message`` parameter is accepted for API symmetry with Boss
+        but is not delivered to the recruiter.
+
+    The ``zhilian_greeting_not_supported`` step in ``_drive_dialog`` will
+    report ``zhilian_resume_submit_has_no_message_editor`` on every healthy
+    Zhilian job page — that is expected behavior, not a bug.
+    """
+
     def __init__(self, driver: Any | None = None, audit_log: ZhilianAuditLog | None = None):
         self.driver = driver
         self.audit_log = audit_log or ZhilianAuditLog()

--- a/src/jobagent/platforms/zhilian/collect.py
+++ b/src/jobagent/platforms/zhilian/collect.py
@@ -119,7 +119,11 @@ class ZhilianReadOnlyCollector:
                 )
 
             remaining = max(1, limit - len(jobs))
-            snapshot = self._extract_snapshot(limit=remaining)
+            # When city filter is active, fetch 2× more cards per page to
+            # compensate for non-matching ones that will be filtered out
+            # (Zhilian's sou endpoint ignores URL city params server-side).
+            fetch_limit = remaining * 2 if city else remaining
+            snapshot = self._extract_snapshot(limit=fetch_limit)
             snapshot["page"] = current_page
             snapshot["requestedUrl"] = url
             snapshots.append(snapshot)
@@ -142,6 +146,9 @@ class ZhilianReadOnlyCollector:
                 if not isinstance(card, dict):
                     continue
                 job = parse_zhilian_job(card, city_name=city)
+                # Apply city post-filter (Zhilian URL params don't filter server-side)
+                if not _city_matches(job.city, city):
+                    continue
                 key = _job_dedupe_key(job, card)
                 if key in seen:
                     continue
@@ -271,12 +278,58 @@ def _combined_snapshot(snapshots: list[dict[str, Any]], fallback: dict[str, Any]
 
 
 def _job_dedupe_key(job: Job, raw: dict[str, Any]) -> str:
+    """Build a stable dedup key for a Zhilian job.
+
+    Priority:
+      1. Explicit job id attribute on the card.
+      2. Job id extracted from URL path (/jobdetail/CCL...J....htm) — Zhilian
+         decorates the same job's URL with different query params per page
+         (refcode, srccode, preactionid, …).
+      3. Full URL fallback.
+      4. Name+company+city text fallback when no URL at all.
+    """
+    import re
+
     job_id = zhilian_job_id(raw)
     if job_id:
         return f"id:{job_id}"
     if job.url:
+        # Zhilian job URLs look like:
+        #   https://www.zhaopin.com/jobdetail/CCL1212903980J40854050007.htm?refcode=...
+        m = re.search(r"/jobdetail/([A-Z0-9]+)\.htm", job.url)
+        if m:
+            return f"job:{m.group(1)}"
         return f"url:{job.url}"
     return f"text:{job.name}|{job.company}|{job.city}"
+
+
+def _city_matches(job_city: str, requested_city: str) -> bool:
+    """Check whether a job's parsed city matches the user-requested city.
+
+    Zhilian's sou endpoint ignores URL city params server-side (jl= param is
+    accepted but doesn't filter results), so search results are a mix of
+    cities. This post-filter is the only reliable way to apply a city filter.
+
+    Matches when:
+      - No requested_city (filter disabled), OR
+      - job_city starts with requested_city (handles "北京" and "北京·朝阳区"), OR
+      - job_city is empty (permissive — better to over-include than drop).
+    """
+    if not requested_city:
+        return True
+    if not job_city:
+        return True  # don't drop cards with missing city field
+    # Zhilian uses "·" as city/area separator ("北京·朝阳区"), Liepin uses "-".
+    # Split on both to get just the top-level city.
+    for sep in ("·", "-"):
+        if sep in job_city:
+            job_city = job_city.split(sep)[0].strip()
+            break
+    for sep in ("·", "-"):
+        if sep in requested_city:
+            requested_city = requested_city.split(sep)[0].strip()
+            break
+    return job_city == requested_city
 
 
 def _snapshot_failure(snapshot: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

The Zhilian vertical chain **worked end-to-end out of the box** (20 jobs → rank → greet preview → 5/5 delivered), but `--city` filter was silently ignored: 20 jobs came back spread across 12 cities (only 4 in 北京). Two issues fixed.

📄 **Full changelog**: [`CHANGELOG.md` — Zhilian beta pipeline section](https://github.com/jiyangnan/AgentMesh-JobAgent/blob/fix/zhilian-pipeline/CHANGELOG.md#unreleased--zhilian-beta-pipeline--2026-06-22)

## Problems → Fixes

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | `--city 北京` returns jobs from 上海/合肥/青岛/...12 cities | Zhilian's `sou.zhaopin.com` accepts `jl=` URL param but doesn't filter server-side | `_city_matches` Python post-filter on parsed `Job.city` (handles `·` and `-` separators) |
| 2 (latent) | Same job on different pages treated as different | URL decorated with `refcode=`/`srccode=`/`preactionid=` per page | Extract `/jobdetail/<ALNUM>.htm` → `job:<id>` dedup key |

## Verification

- **Before**: `--city 北京 --pages 2` → 20 jobs in 12 cities (only 4 in 北京)
- **After**: `--city 北京 --pages 2` → **14 jobs, 14/14 in 北京** ✅
- **End-to-end**: rank + greet preview + apply send → 5/5 delivered (雄安云网/垒知集团/重庆爱责慧/青岛君合融通/点真互联网)
- **Unit tests**: 191/192 passing, no regressions

## Documentation — Zhilian UX clarification

Same pattern as Liepin (PR #2): added explicit docstring to `ZhilianApplySender`:
- Zhilian has **no Boss-style greeting chat flow**
- Only contact mechanism is "立即投递" (submit resume)
- Generated greetings are handoff-only, NOT auto-sent by `apply send`
- The `zhilian_greeting_not_supported` step reporting `zhilian_resume_submit_has_no_message_editor` is **expected behavior**

## Files Changed

```
CHANGELOG.md                                | 35 ++++++
src/jobagent/platforms/zhilian/apply.py     | 21 ++++
src/jobagent/platforms/zhilian/collect.py   | 54 ++++++++++-
3 files changed, 110 insertions(+), 1 deletion(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)