### PR TITLE
docs: link the official Job Agent website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# AgentMesh Job Agent
+# AgentMesh360 Job Agent
 
-Job Agent is an Agent-native job-search product. Its open-source CLI connects recruiting platforms through the user's own browser session, while AgentMesh360 cloud intelligence provides the official candidate profile, job decisions and personalized communication.
+**Official website:** [jobagent.agentmesh360.com](https://jobagent.agentmesh360.com/)
+
+AgentMesh360 Job Agent is an Agent-native job-search product. Its open-source CLI connects recruiting platforms through the user's own browser session, while AgentMesh360 cloud intelligence provides the official candidate profile, job decisions and personalized communication.
 
 The cloud turns the resume into a recruiter-side 36-dimension candidate profile, creates profile-driven search plans, classifies every deduplicated job into signed `selected / review / rejected` results with reasons and risks, and generates evidence-grounded personalized greetings where the platform supports them. The CLI verifies those official results before delivery.
 

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -611,6 +611,17 @@ def test_public_docs_do_not_restore_per_platform_send_confirmation():
     assert "automatic selected delivery" in claude_guide
 
 
+def test_public_readme_identifies_the_official_product_site():
+    root = Path(__file__).resolve().parents[1]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+
+    assert readme.startswith("# AgentMesh360 Job Agent\n")
+    assert (
+        "[jobagent.agentmesh360.com](https://jobagent.agentmesh360.com/)"
+        in readme
+    )
+
+
 def test_public_agent_docs_forbid_batch_login_and_require_vertical_completion():
     root = Path(__file__).resolve().parents[1]
     docs = [


### PR DESCRIPTION
## Summary
- use the unique AgentMesh360 Job Agent product name
- place the official website link at the top of the public README
- add a regression check that prevents the official-domain relationship from disappearing

## Verification
- 263 passed
- public diff contains only README.md and tests/test_cli_v3.py
- public leak review passed

No CLI behavior or release artifact changed.