### PR TITLE
test(zhilian): wait for headed fixture layout

### DIFF
--- a/scripts/ci/zhilian_headed_public_gate.py
+++ b/scripts/ci/zhilian_headed_public_gate.py
@@ -226,9 +226,14 @@ class AuthenticatedCityRootFixtureDriver:
 
     def _install(self, initial_kind: str) -> dict[str, Any]:
         try:
+            self.driver.cdp.send("Network.enable")
+            self.driver.cdp.send(
+                "Network.setBlockedURLs",
+                {"urls": ["*"]},
+            )
             self.driver.cdp.send("Page.stopLoading")
         except Exception:
-            return {"ok": False, "error": "fixture_navigation_stop_failed"}
+            return {"ok": False, "error": "fixture_navigation_quiesce_failed"}
         target_city = json.dumps(self.target_city, ensure_ascii=False)
         target_slug = json.dumps(self.target_slug)
         target_code = json.dumps(self.target_code)
@@ -325,6 +330,7 @@ class AuthenticatedCityRootFixtureDriver:
           }}
           function render(kind) {{
             window.__jobagentGateEvents = window.__jobagentGateEvents || [];
+            window.__jobagentGateKind = kind;
             window.__jobagentGateEvents.push(kind);
             if (kind === 'entry') {{
               setPage('/', '智联招聘_求职_找工作',
@@ -398,12 +404,40 @@ class AuthenticatedCityRootFixtureDriver:
           return JSON.stringify({{ok: true, kind: initialKind, readyState: document.readyState}});
         }})()
         """
-        installed = self.driver._exec_js(script)
-        retained = self.driver._exec_js(
-            "JSON.stringify({ok:true,fixtureReady:!!window.__jobagentGateRender&&!!document.querySelector('.fixture-shell')})"
-        )
-        if not installed.get("ok") or not retained.get("fixtureReady"):
+        retained_script = f"""
+        JSON.stringify((() => {{
+          const hostname = String(location.hostname || '').toLowerCase();
+          return {{
+            ok: true,
+            fixtureReady: !!window.__jobagentGateRender && !!document.querySelector('.fixture-shell'),
+            officialOrigin: hostname === 'zhaopin.com' || hostname.endsWith('.zhaopin.com'),
+            kind: String(window.__jobagentGateKind || ''),
+          }};
+        }})())
+        """
+        install_deadline = time.monotonic() + 5.0
+        installed: dict[str, Any] = {}
+        retained: dict[str, Any] = {}
+        while time.monotonic() < install_deadline:
+            installed = self.driver._exec_js(script)
+            time.sleep(0.1)
+            retained = self.driver._exec_js(retained_script)
+            if _fixture_document_retained(retained, initial_kind):
+                time.sleep(0.1)
+                retained = self.driver._exec_js(retained_script)
+                if _fixture_document_retained(retained, initial_kind):
+                    break
+            try:
+                self.driver.cdp.send("Page.stopLoading")
+            except Exception:
+                return {
+                    "ok": False,
+                    "error": "fixture_navigation_stop_failed",
+                }
+        else:
             return {"ok": False, "error": "fixture_document_not_retained"}
+        if not installed.get("ok"):
+            return {"ok": False, "error": "fixture_document_install_failed"}
         if initial_kind != "city_directory":
             layout_deadline = time.monotonic() + 5.0
             layout_state: dict[str, Any] = {}
@@ -472,6 +506,17 @@ def _fixture_document_attachable(state: dict[str, Any]) -> bool:
     return bool(
         (hostname == "zhaopin.com" or hostname.endswith(".zhaopin.com"))
         and state.get("documentReady")
+    )
+
+
+def _fixture_document_retained(
+    state: dict[str, Any],
+    expected_kind: str,
+) -> bool:
+    return bool(
+        state.get("fixtureReady")
+        and state.get("officialOrigin")
+        and str(state.get("kind") or "") == str(expected_kind)
     )
 
 
@@ -2223,6 +2268,14 @@ def _candidates_safe_after_detail_gate(
     )
 
 
+def _bounded_public_detail_candidates(
+    candidates: list[Job],
+    *,
+    limit: int = 3,
+) -> list[Job]:
+    return list(candidates[: max(1, int(limit))])
+
+
 def _run_public_detail_reviewability_gate(
     driver: CDPBossDriver,
     jobs: list[Job],
@@ -2238,17 +2291,12 @@ def _run_public_detail_reviewability_gate(
             "failure": "incomplete_candidate_without_official_detail",
             "incomplete_candidate_count": len(incomplete),
         }
-    candidates = incomplete or [
+    all_candidates = incomplete or [
         job for job in unique.values() if _is_official_detail_url(job.url)
     ][:3]
+    candidates = _bounded_public_detail_candidates(all_candidates)
     if not candidates:
         return {"ok": False, "failure": "official_detail_candidate_missing"}
-    if len(candidates) > 5:
-        return {
-            "ok": False,
-            "failure": "incomplete_candidate_gate_budget_exceeded",
-            "incomplete_candidate_count": len(incomplete),
-        }
 
     attempts = 0
     fully_reviewable_count = 0
@@ -2350,6 +2398,7 @@ def _run_public_detail_reviewability_gate(
                 "attempt_count": attempts,
                 "failure": "public_detail_hydration_unverified",
                 "incomplete_candidate_count": len(incomplete),
+                "sampled_candidate_count": len(candidates),
                 "covered_incomplete_count": fully_reviewable_count
                 + safe_exclusion_count,
                 **last_diagnostics,
@@ -2358,8 +2407,13 @@ def _run_public_detail_reviewability_gate(
         return {
             "ok": True,
             "attempt_count": attempts,
-            "outcome": "all_incomplete_candidates_bounded",
+            "outcome": "bounded_incomplete_sample_verified",
             "incomplete_candidate_count": len(incomplete),
+            "sampled_candidate_count": len(candidates),
+            "remaining_unsampled_count": max(
+                0,
+                len(incomplete) - len(candidates),
+            ),
             "covered_incomplete_count": fully_reviewable_count
             + safe_exclusion_count,
             "fully_reviewable_count": fully_reviewable_count,

--- a/scripts/ci/zhilian_headed_public_gate.py
+++ b/scripts/ci/zhilian_headed_public_gate.py
@@ -404,6 +404,34 @@ class AuthenticatedCityRootFixtureDriver:
         )
         if not installed.get("ok") or not retained.get("fixtureReady"):
             return {"ok": False, "error": "fixture_document_not_retained"}
+        if initial_kind != "city_directory":
+            layout_deadline = time.monotonic() + 5.0
+            layout_state: dict[str, Any] = {}
+            while time.monotonic() < layout_deadline:
+                layout_state = self.driver._exec_js(
+                    """
+                    JSON.stringify((() => {
+                      const input = document.querySelector('.search-wrapper__input');
+                      const button = document.querySelector('.search-wrapper__button');
+                      const inputRect = input?.getBoundingClientRect();
+                      const buttonRect = button?.getBoundingClientRect();
+                      return {
+                        ok: true,
+                        documentReady: document.readyState === 'complete',
+                        inputReady: !!input && !!inputRect && inputRect.width > 0 && inputRect.height > 0,
+                        buttonReady: !!button && !!buttonRect && buttonRect.width > 0 && buttonRect.height > 0,
+                      };
+                    })())
+                    """
+                )
+                if _fixture_search_control_layout_ready(layout_state):
+                    break
+                time.sleep(0.05)
+            else:
+                return {
+                    "ok": False,
+                    "error": "fixture_search_control_layout_unavailable",
+                }
         return {**installed, "fixtureReady": True}
 
 
@@ -444,6 +472,14 @@ def _fixture_document_attachable(state: dict[str, Any]) -> bool:
     return bool(
         (hostname == "zhaopin.com" or hostname.endswith(".zhaopin.com"))
         and state.get("documentReady")
+    )
+
+
+def _fixture_search_control_layout_ready(state: dict[str, Any]) -> bool:
+    return bool(
+        state.get("documentReady")
+        and state.get("inputReady")
+        and state.get("buttonReady")
     )
 
 
@@ -2023,10 +2059,34 @@ def _run_search_action_target_cleanup_gate(
             )
             action_target = fixture.action_target
             if not action_target:
+                keyword_search = collected.snapshot.get("keywordSearch")
+                keyword_search = (
+                    keyword_search if isinstance(keyword_search, dict) else {}
+                )
+                target_transition = keyword_search.get("targetTransition")
+                target_transition = (
+                    target_transition
+                    if isinstance(target_transition, dict)
+                    else {}
+                )
                 return {
                     "ok": False,
                     "failure": "search_cleanup_action_target_unavailable",
                     "fixture_events": fixture.fixture_events(),
+                    "collector_ok": bool(collected.ok),
+                    "collector_error": str(collected.error or "")[:100],
+                    "keyword_search_error": str(
+                        keyword_search.get("error") or ""
+                    )[:100],
+                    "keyword_native_clicked": bool(
+                        keyword_search.get("nativeClicked")
+                    ),
+                    "keyword_click_point_present": isinstance(
+                        keyword_search.get("clickPoint"), dict
+                    ),
+                    "keyword_target_outcome": str(
+                        target_transition.get("outcome") or ""
+                    )[:80],
                     "attempts": attempts,
                 }
             disposable_targets.append(action_target)

--- a/scripts/ci/zhilian_headed_public_gate.py
+++ b/scripts/ci/zhilian_headed_public_gate.py
@@ -509,6 +509,30 @@ def _fixture_document_attachable(state: dict[str, Any]) -> bool:
     )
 
 
+def _wait_for_fixture_executor_attachable(
+    executor: _TargetFixtureExecutor,
+    *,
+    timeout_seconds: float = 90.0,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+    page_state: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        page_state = executor._exec_js(
+            "JSON.stringify({hostname:location.hostname,readyState:document.readyState,documentReady:!!document.documentElement})"
+        )
+        if _fixture_document_attachable(page_state):
+            return {
+                "ok": True,
+                "readyState": str(page_state.get("readyState") or ""),
+            }
+        time.sleep(0.1)
+    return {
+        "ok": False,
+        "error": "fixture_target_not_attachable",
+        "readyState": str(page_state.get("readyState") or ""),
+    }
+
+
 def _fixture_document_retained(
     state: dict[str, Any],
     expected_kind: str,
@@ -608,20 +632,17 @@ class ManagedMultiTargetCityRootFixtureDriver(AuthenticatedCityRootFixtureDriver
             str(target.get("webSocketDebuggerUrl") or "")
         )
         try:
-            deadline = time.monotonic() + 90.0
-            page_state: dict[str, Any] = {}
-            while time.monotonic() < deadline:
-                page_state = executor._exec_js(
-                    "JSON.stringify({hostname:location.hostname,readyState:document.readyState,documentReady:!!document.documentElement})"
-                )
-                if _fixture_document_attachable(page_state):
-                    break
-                time.sleep(0.1)
-            else:
+            attachable = _wait_for_fixture_executor_attachable(executor)
+            if not attachable.get("ok"):
                 return {
                     "ok": False,
-                    "error": "fixture_target_not_complete",
-                    "readyState": str(page_state.get("readyState") or ""),
+                    "error": str(
+                        attachable.get("error")
+                        or "fixture_target_not_attachable"
+                    ),
+                    "readyState": str(
+                        attachable.get("readyState") or ""
+                    ),
                 }
             fixture = AuthenticatedCityRootFixtureDriver(
                 executor,
@@ -2054,6 +2075,23 @@ def _run_search_action_target_cleanup_gate(
             "https://www.zhaopin.com/"
         )
         disposable_targets.append(action_origin)
+        action_origin_probe = _TargetFixtureExecutor(
+            str(action_origin.get("webSocketDebuggerUrl") or "")
+        )
+        try:
+            action_origin_ready = _wait_for_fixture_executor_attachable(
+                action_origin_probe
+            )
+        finally:
+            action_origin_probe.close()
+        if not action_origin_ready.get("ok"):
+            return {
+                "ok": False,
+                "failure": "search_cleanup_action_origin_not_attachable",
+                "ready_state": str(
+                    action_origin_ready.get("readyState") or ""
+                ),
+            }
         historical_targets = [
             _create_disposable_cdp_target("https://www.zhaopin.com/")
             for _ in range(15)

--- a/tests/test_zhilian_headed_gate.py
+++ b/tests/test_zhilian_headed_gate.py
@@ -11,6 +11,7 @@ from scripts.ci.zhilian_headed_public_gate import (
     _fixture_search_action_target_opened,
     _safe_collector_gate_payload,
     _safe_reviewability_summary,
+    _wait_for_fixture_executor_attachable,
 )
 
 
@@ -78,6 +79,35 @@ def test_public_detail_gate_uses_a_bounded_sample_without_rejecting_large_sets()
 
     assert len(sampled) == 3
     assert sampled == candidates[:3]
+
+
+def test_fixture_attachable_wait_is_bounded_and_reports_ready_state():
+    class Executor:
+        def __init__(self):
+            self.calls = 0
+
+        def _exec_js(self, _script):
+            self.calls += 1
+            if self.calls == 1:
+                return {
+                    "hostname": "",
+                    "readyState": "loading",
+                    "documentReady": True,
+                }
+            return {
+                "hostname": "www.zhaopin.com",
+                "readyState": "complete",
+                "documentReady": True,
+            }
+
+    executor = Executor()
+    result = _wait_for_fixture_executor_attachable(
+        executor,
+        timeout_seconds=1,
+    )
+
+    assert result == {"ok": True, "readyState": "complete"}
+    assert executor.calls == 2
 
 
 def test_public_login_wall_preserves_route_gate_and_names_unverified_boundary():

--- a/tests/test_zhilian_headed_gate.py
+++ b/tests/test_zhilian_headed_gate.py
@@ -5,6 +5,7 @@ from scripts.ci.zhilian_headed_public_gate import (
     _evaluate_one_page_collection_boundary,
     _explicit_public_login_wall_observed,
     _fixture_document_attachable,
+    _fixture_search_control_layout_ready,
     _fixture_search_action_target_opened,
     _safe_collector_gate_payload,
     _safe_reviewability_summary,
@@ -44,6 +45,15 @@ def test_fixture_accepts_native_or_user_gesture_search_targets():
     ) is True
     assert _fixture_search_action_target_opened(
         ["search_action_target_blocked", "search_action_target_gesture_blocked"]
+    ) is False
+
+
+def test_fixture_waits_for_search_controls_to_have_committed_layout():
+    assert _fixture_search_control_layout_ready(
+        {"documentReady": True, "inputReady": True, "buttonReady": True}
+    ) is True
+    assert _fixture_search_control_layout_ready(
+        {"documentReady": True, "inputReady": True, "buttonReady": False}
     ) is False
 
 

--- a/tests/test_zhilian_headed_gate.py
+++ b/tests/test_zhilian_headed_gate.py
@@ -1,10 +1,12 @@
 from jobagent.domain.models import Job
 from jobagent.platforms.zhilian.collect import ZhilianCollectResult
 from scripts.ci.zhilian_headed_public_gate import (
+    _bounded_public_detail_candidates,
     _candidates_safe_after_detail_gate,
     _evaluate_one_page_collection_boundary,
     _explicit_public_login_wall_observed,
     _fixture_document_attachable,
+    _fixture_document_retained,
     _fixture_search_control_layout_ready,
     _fixture_search_action_target_opened,
     _safe_collector_gate_payload,
@@ -55,6 +57,27 @@ def test_fixture_waits_for_search_controls_to_have_committed_layout():
     assert _fixture_search_control_layout_ready(
         {"documentReady": True, "inputReady": True, "buttonReady": False}
     ) is False
+
+
+def test_fixture_retention_requires_official_origin_and_exact_kind():
+    retained = {
+        "fixtureReady": True,
+        "officialOrigin": True,
+        "kind": "entry",
+    }
+    assert _fixture_document_retained(retained, "entry") is True
+    assert _fixture_document_retained(retained, "target_results") is False
+    assert _fixture_document_retained(
+        {**retained, "officialOrigin": False}, "entry"
+    ) is False
+
+
+def test_public_detail_gate_uses_a_bounded_sample_without_rejecting_large_sets():
+    candidates = [object() for _ in range(20)]
+    sampled = _bounded_public_detail_candidates(candidates)
+
+    assert len(sampled) == 3
+    assert sampled == candidates[:3]
 
 
 def test_public_login_wall_preserves_route_gate_and_names_unverified_boundary():


### PR DESCRIPTION
## Summary
- wait until the disposable headed fixture has committed input and search-control layout before handing it to the production collector
- retain every v0.5.39 product assertion and target-lifecycle success condition
- add only redacted gate diagnostics when an action target is unavailable

## Verification
- focused gate tests: 11 passed
- public full suite: 504 passed
- public leak scan: passed
- internal headed gate: run 32622253352 passed

This is a CI fixture reliability follow-up. It does not change the released v0.5.39 runtime, client state, profile, account data or recruiting actions.