### PR TITLE
feat(cli): read-only resume-center bridge for host agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ Start a new round explicitly. Reading status never creates a round:
 jobagent round start
 ```
 
+Read the online resumes the user keeps in the workbench — a free, read-only
+listing with confirmation state and the preparation receipt:
+
+```bash
+jobagent resume list
+```
+
 At least one target city is required. A fresh `resume analyze` asks for cities
 before the cloud call when none were supplied or saved, preventing a second
 paid analysis just to repair an empty city. An older city-less profile receives

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -208,6 +208,28 @@ If `resume analyze` returns `target_cities_required`, ask for the cities and rer
 
 Then execute the returned `jobagent round start`. If it returns `interaction_required`, render its card or fallback text and wait for the target-role answer. Continue through `jobagent interaction respond`; only an accepted structured response or an already-explicit direct `round start` creates the four-platform round. Final delivery authorization is still collected separately after each platform preview.
 
+<a id="resume-online-facts"></a>
+
+### Reading the user's online resumes (workbench facts)
+
+When the user asks how many resumes they have, what their resume profile looks
+like, or whether their resume preparation is ready, run the read-only listing
+first — it reflects the resumes the user maintains in the workbench and never
+charges credits:
+
+```bash
+jobagent resume list
+```
+
+Acceptance: `ok=true` with `source=resume_center`, an online-resume list
+(name, direction, version, confirmation state) and the preparation receipt.
+Answer the user from this output. If `source` is `local_snapshot`, say so: the
+data is this machine's last CLI snapshot and may be outdated. If the command
+returns `resume_center_unavailable`, tell the user the server has not enabled
+the online resume center yet; do not guess from local files instead.
+`jobagent profile show` uses the same cloud-first order and labels its source
+the same way. `resume status --id` is reserved for a later release.
+
 ## 4. Run One Platform
 
 ### Boss直聘

--- a/skills/codex-job-agent/SKILL.md
+++ b/skills/codex-job-agent/SKILL.md
@@ -23,6 +23,13 @@ create a replacement round to recover a failure, or edit account/state files.
 Only `jobagent round start` creates a round; use it only for a user-requested new
 round. Preserve the same account, round, request, Discover and browser session.
 
+When the user asks about their resumes (how many, what the profile looks like,
+or whether preparation is ready), run the read-only `jobagent resume list` and
+answer from its `source=resume_center` output; it never charges credits. If it
+reports `local_snapshot`, say the data is this machine's last CLI snapshot and
+may be outdated; if `resume_center_unavailable`, tell the user the online
+resume center is not enabled. Do not guess from local files instead.
+
 The platform order is Boss -> Liepin -> Zhilian -> 51Job. Complete the current
 platform's login, discovery, signed review, full preview, confirmation, delivery
 and audit before entering the next platform. Do not batch-login platforms.

--- a/src/jobagent/cli.py
+++ b/src/jobagent/cli.py
@@ -81,6 +81,11 @@ def build_parser() -> argparse.ArgumentParser:
     analyze.add_argument("--target-role")
     analyze.add_argument("--target-cities", nargs="*")
     analyze.add_argument("--output", "-o")
+    resume_sub.add_parser("list", help="List the online resumes kept in the workbench")
+    resume_status = resume_sub.add_parser(
+        "status", help="Summarize online resume preparation state"
+    )
+    resume_status.add_argument("--id", help="Reserved for a single-resume view (planned)")
 
     profile = sub.add_parser("profile", help="View the current resume profile")
     profile.add_subparsers(dest="profile_command", required=True).add_parser("show")
@@ -554,6 +559,74 @@ def _doctor_env() -> dict[str, Any]:
         },
         "next_suggested": next_suggested,
         "cloud": cloud,
+    }
+
+
+def _resume_center_overview() -> dict[str, Any]:
+    """Read-only workbench facts: online resumes, confirmation state, receipt."""
+    from jobagent.infra import cloud_client
+
+    preparation = cloud_client.resume_center_preparation()
+    resumes = [
+        {
+            "id": resume.get("id"),
+            "name": resume.get("name"),
+            "target_role": resume.get("target_role"),
+            "version": resume.get("version"),
+            "confirmed": bool(resume.get("confirmed_revision_id")),
+            "has_draft": bool(resume.get("has_draft")),
+            "updated_at": resume.get("updated_at"),
+        }
+        for resume in preparation.get("resumes") or []
+        if isinstance(resume, dict)
+    ]
+    return {
+        "ok": True,
+        "source": "resume_center",
+        "state": preparation.get("state"),
+        "ready": bool(preparation.get("ready")),
+        "resumes": resumes,
+        "receipt": preparation.get("receipt"),
+        "next_suggested": preparation.get("next_suggested"),
+        "workbench_url": preparation.get("workbench_url"),
+    }
+
+
+def _profile_show() -> dict[str, Any]:
+    """Cloud facts first (resume center), local snapshot only as a fallback."""
+    from jobagent.infra import cloud_client
+    from jobagent.infra.state import load_json, profile_path
+
+    fallback_reason: str | None = None
+    try:
+        overview = _resume_center_overview()
+        if overview["resumes"]:
+            return {
+                "ok": True,
+                "source": "resume_center",
+                "state": overview["state"],
+                "resumes": overview["resumes"],
+                "receipt": overview["receipt"],
+                "next_suggested": overview["next_suggested"],
+                "workbench_url": overview["workbench_url"],
+            }
+        fallback_reason = "resume_center_empty"
+    except cloud_client.CloudError as exc:
+        # Auth and permission failures must surface, never mask as local data.
+        if exc.status in (401, 403, 404):
+            raise
+        fallback_reason = f"cloud_error:{exc.code or exc.status}"
+    return {
+        "ok": True,
+        "source": "local_snapshot",
+        "profile": load_json(profile_path()),
+        "stale_warning": (
+            "This is the local snapshot from the last CLI analysis on this "
+            "machine. It may be outdated and does not include workbench "
+            "resumes."
+        ),
+        "fallback_reason": fallback_reason,
+        "next_suggested": "jobagent resume list",
     }
 
 
@@ -1137,7 +1210,7 @@ def _native_dispatch(args: argparse.Namespace) -> dict[str, Any] | None:
         args.command == "init"
         or (args.command == "account" and args.account_command in {"bind", "switch"})
         or (args.command == "round" and args.round_command in {"start", "skip"})
-        or args.command == "resume"
+        or (args.command == "resume" and args.resume_command == "analyze")
         or args.command == "interaction"
     )
     if changes_context and browser_work.has_open():
@@ -1223,11 +1296,22 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
     if args.command == "doctor":
         return _doctor_env()
     if args.command == "resume":
-        return _resume_analyze(args)
-    if args.command == "profile":
-        from jobagent.infra.state import load_json, profile_path
+        if args.resume_command == "analyze":
+            return _resume_analyze(args)
+        if args.resume_command in ("list", "status"):
+            if getattr(args, "id", None):
+                from jobagent.infra.cloud_client import CloudError
 
-        return {"ok": True, "profile": load_json(profile_path())}
+                raise CloudError(
+                    "Single-resume detail arrives in a later release; "
+                    "this version lists every online resume.",
+                    status=400,
+                    code="resume_detail_not_available",
+                )
+            return _resume_center_overview()
+        raise ValueError(f"unknown resume command: {args.resume_command}")
+    if args.command == "profile":
+        return _profile_show()
     if args.command == "platforms":
         from jobagent.platforms import check_all_platforms, check_platform_health, list_platforms
 

--- a/src/jobagent/data/codex_skill/SKILL.md
+++ b/src/jobagent/data/codex_skill/SKILL.md
@@ -23,6 +23,13 @@ create a replacement round to recover a failure, or edit account/state files.
 Only `jobagent round start` creates a round; use it only for a user-requested new
 round. Preserve the same account, round, request, Discover and browser session.
 
+When the user asks about their resumes (how many, what the profile looks like,
+or whether preparation is ready), run the read-only `jobagent resume list` and
+answer from its `source=resume_center` output; it never charges credits. If it
+reports `local_snapshot`, say the data is this machine's last CLI snapshot and
+may be outdated; if `resume_center_unavailable`, tell the user the online
+resume center is not enabled. Do not guess from local files instead.
+
 The platform order is Boss -> Liepin -> Zhilian -> 51Job. Complete the current
 platform's login, discovery, signed review, full preview, confirmation, delivery
 and audit before entering the next platform. Do not batch-login platforms.

--- a/src/jobagent/infra/cloud_client.py
+++ b/src/jobagent/infra/cloud_client.py
@@ -309,6 +309,21 @@ def health() -> dict[str, Any]:
     )
 
 
+def resume_center_preparation() -> dict[str, Any]:
+    """Read-only workbench fact: resume list, confirmation state and receipt.
+
+    Never charges credits and never writes; 503 resume_center_unavailable
+    means the server has not enabled the resume center yet.
+    """
+    return _request(
+        "GET",
+        "/v1/resume-center/preparation",
+        timeout=20,
+        max_attempts=2,
+        operation="resume_center_preparation",
+    )
+
+
 def me(*, api_key: str | None = None) -> dict[str, Any]:
     return _request(
         "GET",

--- a/tests/test_resume_center_cli.py
+++ b/tests/test_resume_center_cli.py
@@ -1,0 +1,185 @@
+"""Resume-center CLI bridge (P1): read-only online resume facts for agents."""
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import pytest
+
+from jobagent.cli import _dispatch, build_parser
+from jobagent.infra import cloud_client
+from jobagent.infra.cloud_client import CloudError
+
+
+def _args(argv: str) -> argparse.Namespace:
+    return build_parser().parse_args(argv.split())
+
+
+def _preparation(
+    *,
+    resumes: list[dict[str, Any]] | None = None,
+    state: str = "ready",
+    ready: bool = True,
+) -> dict[str, Any]:
+    if resumes is None:
+        resumes = [
+            {
+                "id": "resume-a",
+                "name": "数据产品方向",
+                "target_role": "数据产品经理",
+                "status": "active",
+                "version": 5,
+                "material_version": 5,
+                "confirmed_revision_id": "rev-5",
+                "confirmed_revision_number": 2,
+                "confirmed_at": "2026-09-10T01:00:00Z",
+                "updated_at": "2026-09-10T02:00:00Z",
+                "has_draft": False,
+            },
+            {
+                "id": "resume-b",
+                "name": "项目管理方向",
+                "target_role": "项目经理",
+                "status": "active",
+                "version": 2,
+                "material_version": 2,
+                "confirmed_revision_id": None,
+                "confirmed_revision_number": None,
+                "confirmed_at": None,
+                "updated_at": "2026-09-09T02:00:00Z",
+                "has_draft": True,
+            },
+        ]
+    return {
+        "ok": True,
+        "protocol": "agentmesh360.resume_preparation",
+        "protocol_version": 1,
+        "account_ref": "acct_synthetic",
+        "state_revision": 4,
+        "state": state,
+        "ready": ready,
+        "checked_at": "2026-09-11T00:00:00Z",
+        "offline": False,
+        "stale": False,
+        "resumes": resumes,
+        "receipt": {"id": "receipt-1", "confirmed_at": "2026-09-10T01:00:00Z", "revisions": []},
+        "blockers": [],
+        "requires_user_action": not ready,
+        "next_suggested": None,
+        "workbench_url": "https://agentmesh360.com/workbench/#/resumes",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _no_local_snapshot(monkeypatch, tmp_path):
+    # Point the local profile snapshot at an empty directory unless a test
+    # explicitly overrides it, so fallback branches are deterministic.
+    import jobagent.infra.state as state_mod
+
+    monkeypatch.setattr(state_mod, "STATE_DIR", tmp_path, raising=False)
+
+
+def test_resume_list_returns_online_facts(monkeypatch):
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation", lambda: _preparation()
+    )
+    result = _dispatch(_args("resume list"))
+    assert result["ok"] is True and result["source"] == "resume_center"
+    assert result["state"] == "ready" and result["ready"] is True
+    assert [r["name"] for r in result["resumes"]] == ["数据产品方向", "项目管理方向"]
+    assert result["resumes"][0]["confirmed"] is True
+    assert result["resumes"][1]["confirmed"] is False
+    assert result["resumes"][1]["has_draft"] is True
+    # No resume body, no personal info, only user-authored metadata fields.
+    assert all(set(r) == {"id", "name", "target_role", "version", "confirmed", "has_draft", "updated_at"} for r in result["resumes"])
+    assert result["workbench_url"].startswith("https://agentmesh360.com/workbench")
+
+
+def test_resume_status_matches_list_and_detail_is_reserved(monkeypatch):
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation", lambda: _preparation()
+    )
+    assert _dispatch(_args("resume status"))["source"] == "resume_center"
+    with pytest.raises(CloudError) as exc:
+        _dispatch(_args("resume status --id resume-a"))
+    assert exc.value.code == "resume_detail_not_available"
+
+
+def test_resume_list_surfaces_unavailable_as_cloud_error(monkeypatch):
+    def _unavailable():
+        raise CloudError(
+            "resume center is not enabled",
+            status=503,
+            code="resume_center_unavailable",
+        )
+
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", _unavailable)
+    with pytest.raises(CloudError) as exc:
+        _dispatch(_args("resume list"))
+    assert exc.value.code == "resume_center_unavailable"
+
+
+def test_profile_show_prefers_cloud_facts(monkeypatch):
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation", lambda: _preparation()
+    )
+    result = _dispatch(_args("profile show"))
+    assert result["source"] == "resume_center"
+    assert len(result["resumes"]) == 2
+    assert "profile" not in result  # no stale local copy mixed in
+
+
+def test_profile_show_falls_back_to_local_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        cloud_client,
+        "resume_center_preparation",
+        lambda: _preparation(resumes=[], state="empty", ready=False),
+    )
+    import jobagent.infra.state as state_mod
+
+    profile_file = tmp_path / "profile.json"
+    profile_file.write_text('{"basic": {"name": "Synthetic Local"}}', encoding="utf-8")
+    monkeypatch.setattr(state_mod, "profile_path", lambda: profile_file)
+    result = _dispatch(_args("profile show"))
+    assert result["source"] == "local_snapshot"
+    assert result["profile"]["basic"]["name"] == "Synthetic Local"
+    assert "may be outdated" in result["stale_warning"]
+    assert result["fallback_reason"] == "resume_center_empty"
+    assert result["next_suggested"] == "jobagent resume list"
+
+
+def test_profile_show_falls_back_on_unreachable_cloud(monkeypatch, tmp_path):
+    def _down():
+        raise CloudError("tls eof", status=502, code="cloud_gateway_unavailable", retryable=True)
+
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", _down)
+    import jobagent.infra.state as state_mod
+
+    monkeypatch.setattr(state_mod, "profile_path", lambda: tmp_path / "missing.json")
+    result = _dispatch(_args("profile show"))
+    assert result["source"] == "local_snapshot"
+    assert result["profile"] is None
+    assert result["fallback_reason"] == "cloud_error:cloud_gateway_unavailable"
+
+
+def test_profile_show_never_masks_auth_failures(monkeypatch):
+    def _denied():
+        raise CloudError("invalid key", status=401, code="invalid_api_key")
+
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", _denied)
+    with pytest.raises(CloudError) as exc:
+        _dispatch(_args("profile show"))
+    assert exc.value.status == 401
+
+
+def test_resume_list_is_read_only_and_not_context_locked(monkeypatch):
+    # The native-work context lock exists for commands that change profile or
+    # round context; a read-only listing must stay available.
+    from jobagent.infra import browser_work
+
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation", lambda: _preparation()
+    )
+    monkeypatch.setattr(browser_work, "has_open", lambda: True)
+    result = _dispatch(_args("resume list"))
+    assert result["source"] == "resume_center"


### PR DESCRIPTION
Adds resume list/status and cloud-first profile show with labeled fallback; onboarding/README/Codex skill instructions. Read-only, zero credits, no schema changes. Full suite 1010 passed.