### PR TITLE
feat(cli): bind each delivery round to a user-confirmed resume

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -208,6 +208,19 @@ If `resume analyze` returns `target_cities_required`, ask for the cities and rer
 
 Then execute the returned `jobagent round start`. If it returns `interaction_required`, render its card or fallback text and wait for the target-role answer. Continue through `jobagent interaction respond`; only an accepted structured response or an already-explicit direct `round start` creates the four-platform round. Final delivery authorization is still collected separately after each platform preview.
 
+When the account has confirmed workbench resumes, `round start` first returns a
+`resume_selection` interaction: render its card (or numbered fallback) and let
+the user pick the resume for this round's deliveries — even when only one
+resume is confirmed. Continue with `jobagent interaction respond --interaction-id <id> --resume-id <resume-id>`, then run `jobagent round start` again to finish
+city/role confirmation. The chosen resume appears as `resume_binding` in
+`round start`/`round status` output, and every delivered job records it in the
+workbench's applications view. `--resume-binding <binding-id>` adopts an
+existing binding directly; `--no-resume-binding` keeps the classic local-profile
+path. If a platform command returns `preparation_required` with
+`resume_binding_paused`, the bound resume changed: the platform is paused — ask
+the user to choose a resume again via `jobagent round start`; do not deliver
+with an unbound profile in that round.
+
 <a id="resume-online-facts"></a>
 
 ### Reading the user's online resumes (workbench facts)

--- a/src/jobagent/application/discover.py
+++ b/src/jobagent/application/discover.py
@@ -424,6 +424,13 @@ def run_discover(
     require_compatible_profile(profile)
     active_round = rounds.ensure_current_round()
     round_intent = active_round.get("intent")
+    round_binding = active_round.get("resume_binding") or {}
+    binding_material = None
+    if round_binding.get("id"):
+        # Bound rounds discover with the confirmed resume's own material so
+        # the signed plan — and the workbench delivery record — name it.
+        binding_material = cloud_client.resume_binding_material(round_binding["id"])
+        profile = binding_material["profile"]
     resumed = _resume_pending_decision(
         platform,
         profile=profile,
@@ -445,8 +452,29 @@ def run_discover(
             plan = collection["plan"] if collection is not None else cloud_client.discovery_start(
                 platform=platform, profile=profile, request_id=request_id,
                 round_intent=round_intent,
+                resume_binding_id=round_binding.get("id") if round_binding.get("id") else None,
+                context_id=binding_material.get("context_id") if binding_material else None,
+                round_id=str(active_round.get("round_id")) if round_binding.get("id") else None,
             )
     except cloud_client.CloudError as exc:
+        if exc.code == "preparation_required" and round_binding.get("id"):
+            # The bound resume changed underneath this round. Pause this
+            # platform's flow and ask for a fresh user-confirmed selection.
+            rounds.clear_round_resume_binding()
+            exc.details.update(
+                {
+                    "resume_binding_paused": True,
+                    "message": (
+                        "The resume bound to this round changed and is no longer "
+                        "usable. This platform is paused; choose a resume again "
+                        "before continuing."
+                    ),
+                    "next_suggested": "jobagent round start",
+                    "no_charge": True,
+                    "billing_status": "not_charged",
+                }
+            )
+            raise
         exc.details.update(
             {
                 "request_preserved": True,

--- a/src/jobagent/application/round_resume_binding.py
+++ b/src/jobagent/application/round_resume_binding.py
@@ -1,0 +1,190 @@
+"""Round-scoped resume binding: the user-confirmed resume for deliveries.
+
+The binding flows preparation -> selection interaction -> respond -> binding,
+then rides the round state into discovery so signed decisions — and the
+workbench application records they import — name the exact resume revision.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from jobagent.infra import cloud_client
+
+
+def pending_binding_path():
+    from jobagent.infra.state import STATE_DIR, ensure_dirs
+
+    ensure_dirs()
+    return STATE_DIR / "pending_round_binding.json"
+
+
+def load_pending_binding() -> dict[str, Any] | None:
+    from jobagent.infra.state import load_json
+
+    return load_json(pending_binding_path())
+
+
+def save_pending_binding(value: dict[str, Any]) -> None:
+    from jobagent.infra.state import save_json
+
+    save_json(pending_binding_path(), value)
+
+
+def clear_pending_binding() -> None:
+    path = pending_binding_path()
+    if path.exists():
+        path.unlink()
+
+
+def binding_summary(binding: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not binding or not binding.get("id"):
+        return None
+    return {
+        "id": binding.get("id"),
+        "context_id": binding.get("context_id"),
+        "resume_id": binding.get("resume_id"),
+        "resume_name": binding.get("resume_name"),
+        "target_role": binding.get("target_role"),
+        "resume_revision_id": binding.get("resume_revision_id"),
+        "resume_revision_number": binding.get("resume_revision_number"),
+    }
+
+
+def begin_resume_selection() -> dict[str, Any]:
+    """Start the user-confirmed resume choice for the coming round.
+
+    Returns {"interaction": payload} when the user must choose (always, even
+    with a single confirmed resume — decision D-B1), {"notice": text} when
+    there is nothing prepared (old local-profile path continues), or
+    {"error": payload} when the resume center is reachable but rejects the
+    selection request.
+    """
+    preparation = cloud_client.resume_center_preparation()
+    if not preparation.get("ready"):
+        return {"notice": "no_prepared_resumes"}
+    context_id = f"cli-round-{uuid.uuid4()}"
+    selection = cloud_client.resume_selection(
+        context_id, int(preparation["state_revision"])
+    )
+    interaction = selection.get("interaction") or {}
+    options = (
+        (interaction.get("fields") or [{}])[0].get("options")
+        if isinstance(interaction.get("fields"), list)
+        else None
+    ) or []
+    from jobagent.infra.interaction_state import save_pending_interaction
+
+    save_pending_interaction(
+        interaction,
+        stage="resume_binding",
+        context={
+            "selection_id": str(
+                selection.get("selection", {}).get("id")
+                or interaction.get("interaction_id")
+                or ""
+            ),
+            "round_context_id": context_id,
+            "response_id": f"cli-response-{uuid.uuid4()}",
+            "options": [
+                {"resume_id": o.get("option_id"), "label": o.get("label")}
+                for o in options
+            ],
+        },
+    )
+    fallback = str(interaction.get("fallback_text") or "")
+    return {
+        "interaction": {
+            "ok": False,
+            "error": "interaction_required",
+            "interaction": interaction,
+            "message": (
+                "Choose the confirmed resume for this round's deliveries; "
+                "every delivered job will record it."
+            ),
+            "next_suggested": "jobagent interaction respond --interaction-id "
+            + str(interaction.get("interaction_id") or "")
+            + " --resume-id <resume-id>",
+            "fallback_text": fallback,
+        }
+    }
+
+
+def respond_resume_selection(pending: dict[str, Any], resume_id: str) -> dict[str, Any]:
+    """Submit the user's choice and stage the binding for the round."""
+    context = pending.get("context") or {}
+    selection_id = str(context.get("selection_id") or "")
+    if not selection_id:
+        return {
+            "ok": False,
+            "error": "invalid_interaction_response",
+            "message": "The resume selection is no longer pending.",
+            "next_suggested": "jobagent round start",
+        }
+    options = context.get("options") or []
+    valid = {str(o.get("resume_id")) for o in options}
+    if resume_id not in valid:
+        return {
+            "ok": False,
+            "error": "invalid_interaction_response",
+            "message": "Choose one of the offered resumes.",
+            "next_suggested": str((pending.get("interaction") or {}).get("fallback_text") or ""),
+        }
+    result = cloud_client.resume_selection_respond(
+        selection_id, str(context.get("response_id") or ""), resume_id
+    )
+    binding = result.get("binding") or {}
+    if not binding.get("id"):
+        return {
+            "ok": False,
+            "error": "resume_binding_invalid",
+            "message": "The server did not return a usable resume binding.",
+            "next_suggested": "jobagent round start",
+        }
+    save_pending_binding({"binding": binding})
+    return {
+        "ok": True,
+        "resume_binding": binding_summary(binding),
+        "next_suggested": "jobagent round start",
+    }
+
+
+def resolve_round_binding(
+    *, explicit_binding: str | None, no_binding: bool, current_round: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Decide the binding for this round start call.
+
+    Order: --no-resume-binding clears everything; an already-bound active
+    round or a staged pending binding is reused; --resume-binding validates
+    and adopts; otherwise the user chooses via the selection interaction.
+    """
+    if no_binding:
+        clear_pending_binding()
+        return {"binding": None}
+    existing = (current_round or {}).get("resume_binding") if (current_round or {}).get("status") == "active" else None
+    if existing and existing.get("id"):
+        return {"binding": existing}
+    staged = load_pending_binding()
+    if staged and staged.get("binding", {}).get("id"):
+        return {"binding": staged["binding"]}
+    if explicit_binding:
+        material = cloud_client.resume_binding_material(explicit_binding)
+        binding = material.get("resume_binding") or {}
+        if binding.get("id") != explicit_binding:
+            return {
+                "error": {
+                    "ok": False,
+                    "error": "resume_binding_invalid",
+                    "message": "The server did not confirm this resume binding.",
+                    "next_suggested": "jobagent round start",
+                }
+            }
+        save_pending_binding({"binding": binding})
+        return {"binding": binding}
+    try:
+        return begin_resume_selection()
+    except cloud_client.CloudError as exc:
+        if exc.status in (401, 403, 404):
+            raise
+        # Unprepared or unreachable resume center keeps the classic path.
+        return {"notice": f"resume_center_skipped:{exc.code or exc.status}"}

--- a/src/jobagent/cli.py
+++ b/src/jobagent/cli.py
@@ -147,6 +147,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target city supplied for city confirmation; repeat for multiple cities",
     )
     interaction_respond.add_argument(
+        "--resume-id",
+        help="Resume id chosen for the round resume-binding confirmation",
+    )
+    interaction_respond.add_argument(
         "--exclude-index",
         action="append",
         type=int,
@@ -167,6 +171,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help="Explicit target role for this round; repeat for multiple roles",
+    )
+    round_start.add_argument(
+        "--resume-binding",
+        metavar="BINDING_ID",
+        help="Bind this round's deliveries to an existing workbench resume binding",
+    )
+    round_start.add_argument(
+        "--no-resume-binding",
+        action="store_true",
+        help="Skip resume binding and use the local profile for this round",
     )
     round_sub.add_parser("status")
     round_audit = round_sub.add_parser("audit")
@@ -717,6 +731,19 @@ def _resume_analyze(args: argparse.Namespace) -> dict[str, Any]:
     return result
 
 
+def _staged_resume_binding() -> dict[str, Any] | None:
+    from jobagent.application.round_resume_binding import load_pending_binding
+
+    staged = load_pending_binding()
+    return (staged or {}).get("binding") or None
+
+
+def _consume_staged_resume_binding() -> None:
+    from jobagent.application.round_resume_binding import clear_pending_binding
+
+    clear_pending_binding()
+
+
 def _interaction_respond(args: argparse.Namespace) -> dict[str, Any]:
     from jobagent.application.round_intent import (
         build_round_intent_from_choice,
@@ -763,6 +790,41 @@ def _interaction_respond(args: argparse.Namespace) -> dict[str, Any]:
             choice=str(args.choice or pending.get("choice") or ""),
             exclude_indices=list(args.exclude_index or []),
         )
+    if pending and str(pending.get("stage") or "") == "resume_binding":
+        from jobagent.application.round_resume_binding import (
+            load_pending_binding,
+            respond_resume_selection,
+        )
+
+        if str(pending.get("interaction_id") or "") != interaction_id:
+            return {
+                "ok": False,
+                "error": "interaction_not_pending",
+                "message": "This resume selection is no longer waiting for that answer.",
+                "next_suggested": "jobagent round start",
+            }
+        resume_id = str(args.resume_id or "").strip()
+        if not resume_id:
+            return {
+                "ok": False,
+                "error": "invalid_interaction_response",
+                "message": "Pass --resume-id with one of the offered resume ids.",
+                "next_suggested": str(
+                    (pending.get("interaction") or {}).get("fallback_text") or ""
+                ),
+            }
+        result = respond_resume_selection(pending, resume_id)
+        if result.get("ok"):
+            clear_pending_interaction()
+            staged = load_pending_binding()
+            binding = (staged or {}).get("binding") or {}
+            current = load_json(current_round_path())
+            if binding.get("id") and current and current.get("status") == "active" and current.get("round_id"):
+                from jobagent.infra.rounds import attach_round_resume_binding
+
+                attach_round_resume_binding(binding)
+                result["workflow"] = round_status()
+        return result
     profile = load_json(profile_path())
     if not profile:
         return {
@@ -936,8 +998,18 @@ def _interaction_respond(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "completed_at": utc_now(),
     }
-    start_new_round(intent, interaction_receipt=receipt)
+    created = start_new_round(
+        intent,
+        interaction_receipt=receipt,
+        resume_binding=_staged_resume_binding(),
+    )
+    if not created.get("resume_binding") and _staged_resume_binding():
+        # The round already existed; attach the staged binding to it.
+        from jobagent.infra.rounds import attach_round_resume_binding
+
+        attach_round_resume_binding(_staged_resume_binding())
     clear_pending_interaction()
+    _consume_staged_resume_binding()
     return {
         "ok": True,
         "interaction_receipt": receipt,
@@ -1365,6 +1437,23 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
                     "message": "Analyze a resume before confirming target roles.",
                     "next_suggested": "jobagent resume analyze --file <resume>",
                 }
+            # --- user-confirmed resume binding for this round (P2) ---
+            from jobagent.application.round_resume_binding import (
+                binding_summary,
+                resolve_round_binding,
+            )
+
+            binding_stage = resolve_round_binding(
+                explicit_binding=args.resume_binding,
+                no_binding=args.no_resume_binding,
+                current_round=current,
+            )
+            if binding_stage.get("error"):
+                return binding_stage["error"]
+            if binding_stage.get("interaction"):
+                return binding_stage["interaction"]
+            round_binding = binding_stage.get("binding")
+            resume_notice = binding_stage.get("notice")
             if not confirmed_target_cities(profile):
                 confirmation = target_city_input_request(
                     profile,
@@ -1398,8 +1487,20 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
                 and not args.target_role
             ):
                 clear_pending_interaction()
-                start_new_round()
-                return {"ok": True, "workflow": round_status()}
+                active = start_new_round()
+                if not active.get("resume_binding") and round_binding:
+                    from jobagent.infra.rounds import attach_round_resume_binding
+
+                    attach_round_resume_binding(round_binding)
+                    _consume_staged_resume_binding()
+                return {
+                    "ok": True,
+                    "resume_binding": binding_summary(
+                        (load_json(current_round_path()) or {}).get("resume_binding")
+                    ),
+                    "resume_notice": resume_notice,
+                    "workflow": round_status(),
+                }
             if not args.accept_suggested and not args.target_role:
                 confirmation = target_role_confirmation(
                     profile,
@@ -1433,9 +1534,16 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
                     "message": str(exc),
                     "next_suggested": "jobagent round start",
                 }
-            start_new_round(intent)
+            created = start_new_round(intent, resume_binding=round_binding)
             clear_pending_interaction()
-            return {"ok": True, "workflow": round_status()}
+            if round_binding:
+                _consume_staged_resume_binding()
+            return {
+                "ok": True,
+                "resume_binding": binding_summary(created.get("resume_binding")),
+                "resume_notice": resume_notice,
+                "workflow": round_status(),
+            }
         if args.round_command == "status":
             return {"ok": True, "workflow": round_status()}
         if args.round_command == "audit":

--- a/src/jobagent/infra/cloud_client.py
+++ b/src/jobagent/infra/cloud_client.py
@@ -324,6 +324,45 @@ def resume_center_preparation() -> dict[str, Any]:
     )
 
 
+def resume_selection(context_id: str, expected_state_revision: int) -> dict[str, Any]:
+    """Ask the user which confirmed resume this round delivers with."""
+    return _request(
+        "POST",
+        "/v1/resume-center/selections",
+        {
+            "context_id": context_id,
+            "expected_state_revision": expected_state_revision,
+            "idempotency_key": f"cli-selection:{context_id}",
+        },
+        timeout=20,
+        operation="resume_selection",
+    )
+
+
+def resume_selection_respond(
+    selection_id: str, response_id: str, resume_id: str
+) -> dict[str, Any]:
+    """Submit the user's resume choice; returns the bound resume binding."""
+    return _request(
+        "POST",
+        f"/v1/resume-center/selections/{selection_id}/respond",
+        {"response_id": response_id, "resume_id": resume_id},
+        timeout=20,
+        operation="resume_selection_respond",
+    )
+
+
+def resume_binding_material(binding_id: str) -> dict[str, Any]:
+    """Confirmed material snapshot for a binding: profile, digest, identity."""
+    return _request(
+        "GET",
+        f"/v1/resume-center/bindings/{binding_id}/material",
+        timeout=20,
+        max_attempts=2,
+        operation="resume_binding_material",
+    )
+
+
 def me(*, api_key: str | None = None) -> dict[str, Any]:
     return _request(
         "GET",
@@ -384,10 +423,13 @@ def discovery_start(
     profile: dict[str, Any],
     request_id: str,
     round_intent: dict[str, Any] | None = None,
+    resume_binding_id: str | None = None,
+    context_id: str | None = None,
+    round_id: str | None = None,
 ) -> dict[str, Any]:
     from jobagent.infra.protocol import digest_payload
 
-    body = {
+    body: dict[str, Any] = {
         "platform": platform,
         "profile": profile,
         "profile_digest": digest_payload(profile),
@@ -398,6 +440,12 @@ def discovery_start(
     if round_intent and round_intent.get("status") == "confirmed":
         body["round_intent"] = round_intent
         body["intent_digest"] = digest_payload(round_intent)
+    if resume_binding_id:
+        body["resume_binding_id"] = resume_binding_id
+        if context_id:
+            body["context_id"] = context_id
+        if round_id:
+            body["round_id"] = round_id
     return _request(
         "POST",
         "/v1/discovery/start",

--- a/src/jobagent/infra/rounds.py
+++ b/src/jobagent/infra/rounds.py
@@ -86,6 +86,7 @@ def _create_round(
     intent: dict[str, Any] | None = None,
     *,
     interaction_receipt: dict[str, Any] | None = None,
+    resume_binding: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Create the persisted round state for the explicit start command."""
 
@@ -109,16 +110,41 @@ def _create_round(
         },
         "platforms": _default_platform_state(),
     }
+    if resume_binding and resume_binding.get("id"):
+        state["resume_binding"] = resume_binding
     if interaction_receipt is not None:
         state["interaction_receipt"] = interaction_receipt
     save_round(state)
     return state
 
 
+def attach_round_resume_binding(binding: dict[str, Any]) -> dict[str, Any] | None:
+    """Bind (or rebind) the active round after a user-confirmed selection."""
+    current = load_json(current_round_path())
+    if not current or current.get("status") != "active" or not current.get("round_id"):
+        return None
+    current["resume_binding"] = binding
+    current["updated_at"] = utc_now()
+    save_round(current)
+    return current
+
+
+def clear_round_resume_binding() -> dict[str, Any] | None:
+    """Drop the binding after the server reports it stale (pause + reselect)."""
+    current = load_json(current_round_path())
+    if not current or not current.get("resume_binding"):
+        return None
+    current.pop("resume_binding", None)
+    current["updated_at"] = utc_now()
+    save_round(current)
+    return current
+
+
 def start_new_round(
     intent: dict[str, Any] | None = None,
     *,
     interaction_receipt: dict[str, Any] | None = None,
+    resume_binding: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Start a round explicitly, or return the already-active round."""
     current = load_json(current_round_path())
@@ -136,7 +162,9 @@ def start_new_round(
                 }
             )
         return active
-    return _create_round(intent, interaction_receipt=interaction_receipt)
+    return _create_round(
+        intent, interaction_receipt=interaction_receipt, resume_binding=resume_binding
+    )
 
 
 def _migrate_round(state: dict[str, Any]) -> dict[str, Any]:
@@ -620,6 +648,7 @@ def round_status() -> dict[str, Any]:
         "browser_executor": state.get("browser_executor", DEFAULT_BROWSER_EXECUTOR),
         "native_session": deepcopy(state.get("native_session")),
         "intent": state.get("intent"),
+        "resume_binding": state.get("resume_binding"),
         "profile_reconciliation": state.get("profile_reconciliation"),
         "platforms": platforms,
         "current_platform": current_platform,

--- a/tests/test_round_resume_binding.py
+++ b/tests/test_round_resume_binding.py
@@ -1,0 +1,237 @@
+"""Round resume binding (P2): user-confirmed resume rides the delivery chain."""
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import pytest
+
+from jobagent.cli import _dispatch, build_parser
+from jobagent.infra import cloud_client
+from jobagent.infra.cloud_client import CloudError
+from jobagent.infra.interaction_state import load_pending_interaction
+
+
+def _args(argv: str) -> argparse.Namespace:
+    return build_parser().parse_args(argv.split())
+
+
+def _profile() -> dict[str, Any]:
+    return {
+        "basic": {"name": "Synthetic"},
+        "_meta": {"targetRolePolicyVersion": 2},
+        "preferences": {"targetRoles": [{"title": "Engineer", "priority": 1}], "targetCities": [{"city": "Hangzhou", "priority": 1}]},
+    }
+
+
+def _preparation(ready: bool = True, resumes: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    if resumes is None:
+        resumes = [
+            {"id": "resume-a", "name": "数据方向", "target_role": "数据产品经理",
+             "version": 5, "confirmed_revision_id": "rev-5", "has_draft": False,
+             "updated_at": "2026-09-11T00:00:00Z"},
+            {"id": "resume-b", "name": "项目方向", "target_role": "项目经理",
+             "version": 2, "confirmed_revision_id": "rev-2", "has_draft": False,
+             "updated_at": "2026-09-11T00:00:00Z"},
+        ]
+    return {
+        "ok": True, "state": "ready" if ready else "empty", "ready": ready,
+        "state_revision": 7, "resumes": resumes,
+        "receipt": {"id": "receipt-1", "confirmed_at": "2026-09-11T00:00:00Z", "revisions": []},
+        "next_suggested": None,
+        "workbench_url": "https://agentmesh360.com/workbench/#/resumes",
+    }
+
+
+def _selection(resume_ids=("resume-a", "resume-b")) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "selection": {"id": "selection-1", "context_id": "ctx-1", "status": "pending",
+                      "expected_state_revision": 7, "options": []},
+        "interaction": {
+            "event": "interaction_required",
+            "protocol": "agentmesh360.interaction_required",
+            "protocol_version": 1,
+            "interaction_id": "selection-1",
+            "kind": "resume_selection",
+            "title": "Select resume",
+            "prompt": "Choose the confirmed resume for this context.",
+            "required": True,
+            "preferred_presentation": "card",
+            "allow_text_fallback": True,
+            "fields": [
+                {"field_id": "resume_id", "type": "single", "label": "Resume",
+                 "options": [
+                     {"option_id": rid, "label": rid, "description": rid} for rid in resume_ids
+                 ]}
+            ],
+            "fallback_text": "Choose one resume_id: resume-a; resume-b",
+            "continuation": {"action": "jobagent interaction respond", "idempotency_key": "selection-1"},
+        },
+    }
+
+
+def _binding(binding_id: str = "binding-1", resume_id: str = "resume-a") -> dict[str, Any]:
+    return {
+        "id": binding_id, "context_id": "ctx-1", "resume_id": resume_id,
+        "resume_revision_id": "rev-5", "resume_revision_number": 2,
+        "content_digest": "digest", "target_role": "数据产品经理",
+        "resume_name": "数据方向", "confirmed_at": "2026-09-11T00:00:00Z",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch, tmp_path):
+    import jobagent.infra.state as state_mod
+    from pathlib import Path
+
+    monkeypatch.setattr(state_mod, "STATE_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(state_mod, "PROFILE_DIR", tmp_path, raising=False)
+    state_mod.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    profile_file = tmp_path / "profile.json"
+    profile_file.write_text(__import__("json").dumps(_profile()), encoding="utf-8")
+    monkeypatch.setattr(state_mod, "profile_path", lambda: profile_file)
+    yield
+
+
+def test_round_start_asks_for_resume_even_with_one_confirmed(monkeypatch):
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation",
+        lambda: _preparation(resumes=[_preparation()["resumes"][0]]),
+    )
+    monkeypatch.setattr(cloud_client, "resume_selection", lambda context_id, revision: _selection(("resume-a",)))
+    result = _dispatch(_args("round start"))
+    assert result["error"] == "interaction_required"
+    interaction = result["interaction"]
+    assert interaction["kind"] == "resume_selection"
+    pending = load_pending_interaction()
+    assert pending["stage"] == "resume_binding"
+    assert pending["context"]["selection_id"] == "selection-1"
+    assert {o["resume_id"] for o in pending["context"]["options"]} == {"resume-a"}
+
+
+def test_resume_respond_stages_binding_and_round_start_uses_it(monkeypatch):
+    monkeypatch.setattr(
+        cloud_client, "resume_center_preparation", lambda: _preparation()
+    )
+    monkeypatch.setattr(cloud_client, "resume_selection", lambda context_id, revision: _selection())
+    _dispatch(_args("round start"))
+    monkeypatch.setattr(
+        cloud_client, "resume_selection_respond",
+        lambda selection_id, response_id, resume_id: {"ok": True, "binding": _binding(resume_id=resume_id)},
+    )
+    answer = _dispatch(_args("interaction respond --interaction-id selection-1 --resume-id resume-b"))
+    assert answer["ok"] is True
+    assert answer["resume_binding"]["resume_id"] == "resume-b"
+    assert answer["next_suggested"] == "jobagent round start"
+    # Second round start reuses the staged binding without a new selection.
+    result = _dispatch(_args("round start --accept-suggested"))
+    assert result["ok"] is True
+    assert result["resume_binding"]["resume_id"] == "resume-b"
+
+
+def test_resume_respond_rejects_unoffered_resume(monkeypatch):
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", lambda: _preparation())
+    monkeypatch.setattr(cloud_client, "resume_selection", lambda context_id, revision: _selection())
+    _dispatch(_args("round start"))
+    result = _dispatch(_args("interaction respond --interaction-id selection-1 --resume-id resume-x"))
+    assert result["error"] == "invalid_interaction_response"
+    assert cloud_client.resume_selection_respond is not None
+
+
+def test_no_resume_binding_keeps_classic_path(monkeypatch):
+    called = []
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", lambda: (_ for _ in ()).throw(AssertionError("must not call")))
+    result = _dispatch(_args("round start --no-resume-binding --accept-suggested"))
+    assert result["ok"] is True
+    assert result.get("resume_binding") is None
+    assert called == []
+
+
+def test_explicit_binding_is_adopted_after_material_check(monkeypatch):
+    material = {"resume_binding": _binding(), "context_id": "ctx-1",
+                "profile": _profile(), "profile_digest": "digest", "resume_text": "text"}
+    monkeypatch.setattr(cloud_client, "resume_binding_material", lambda binding_id: material)
+    result = _dispatch(_args("round start --resume-binding binding-1 --accept-suggested"))
+    assert result["ok"] is True
+    assert result["resume_binding"]["id"] == "binding-1"
+
+
+def test_unreachable_resume_center_falls_back_to_classic_path(monkeypatch):
+    def _down():
+        raise CloudError("unavailable", status=503, code="resume_center_unavailable")
+
+    monkeypatch.setattr(cloud_client, "resume_center_preparation", _down)
+    result = _dispatch(_args("round start --accept-suggested"))
+    assert result["ok"] is True
+    assert result.get("resume_binding") is None
+    assert "resume_center_skipped" in (result.get("resume_notice") or "")
+
+
+def test_bound_discover_uses_material_profile_and_carries_binding(monkeypatch):
+    from jobagent.application import discover as discover_mod
+    from jobagent.infra import rounds as rounds_mod
+
+    rounds_mod.clear_round_resume_binding()
+    material = {
+        "resume_binding": _binding(),
+        "context_id": "ctx-1",
+        "profile": {"basic": {"name": "云端画像"}},
+        "profile_digest": "cloud-digest",
+        "resume_text": "text",
+    }
+    captured: dict[str, Any] = {}
+
+    def _fake_start(**kwargs):
+        captured.update(kwargs)
+        raise CloudError("stop-here", status=502, code="cloud_gateway_unavailable", retryable=False)
+
+    active = {"round_id": "round-1", "status": "active", "resume_binding": _binding(),
+              "intent": {"status": "confirmed", "target_roles": ["数据产品经理"]}, "platforms": {}}
+    monkeypatch.setattr(rounds_mod, "ensure_current_round", lambda: active)
+    monkeypatch.setattr(cloud_client, "resume_binding_material", lambda binding_id: material)
+    monkeypatch.setattr(cloud_client, "discovery_start", _fake_start)
+    monkeypatch.setattr(discover_mod, "_resume_pending_decision", lambda *a, **k: None)
+    monkeypatch.setattr(discover_mod, "_start_context", lambda *a, **k: {"round_id": "round-1", "platform": "boss", "profile_digest": "cloud-digest"})
+    monkeypatch.setattr(discover_mod, "save_pending_start", lambda *a, **k: None)
+    monkeypatch.setattr(discover_mod, "load_collection_checkpoint", lambda platform: None)
+    import jobagent.infra.state as state_mod
+    monkeypatch.setattr(state_mod, "profile_path", lambda: __import__("pathlib").Path("/nonexistent"))
+    with pytest.raises(CloudError):
+        discover_mod.run_discover("boss")
+    assert captured.get("resume_binding_id") == "binding-1"
+    assert captured.get("context_id") == "ctx-1"
+    assert captured.get("round_id") == "round-1"
+    assert captured.get("profile") == {"basic": {"name": "云端画像"}}
+
+
+def test_stale_binding_pauses_and_clears_for_reselection(monkeypatch):
+    from jobagent.application import discover as discover_mod
+    from jobagent.infra import rounds as rounds_mod
+
+    material = {"resume_binding": _binding(), "context_id": "ctx-1",
+                "profile": {"basic": {"name": "x"}}, "profile_digest": "d", "resume_text": "t"}
+    active = {"round_id": "round-1", "status": "active", "resume_binding": _binding(),
+              "intent": {"status": "confirmed", "target_roles": ["数据产品经理"]}, "platforms": {}}
+    monkeypatch.setattr(rounds_mod, "ensure_current_round", lambda: active)
+    monkeypatch.setattr(cloud_client, "resume_binding_material", lambda binding_id: material)
+
+    def _stale(**kwargs):
+        raise CloudError("Confirm resume preparation and explicitly select material for this task.",
+                         status=409, code="preparation_required")
+
+    monkeypatch.setattr(cloud_client, "discovery_start", _stale)
+    monkeypatch.setattr(discover_mod, "_resume_pending_decision", lambda *a, **k: None)
+    monkeypatch.setattr(discover_mod, "_start_context", lambda *a, **k: {"round_id": "round-1", "platform": "boss", "profile_digest": "d"})
+    monkeypatch.setattr(discover_mod, "save_pending_start", lambda *a, **k: None)
+    monkeypatch.setattr(discover_mod, "load_collection_checkpoint", lambda platform: None)
+    import jobagent.infra.state as state_mod
+    monkeypatch.setattr(state_mod, "profile_path", lambda: __import__("pathlib").Path("/nonexistent"))
+    cleared: list[bool] = []
+    monkeypatch.setattr(rounds_mod, "clear_round_resume_binding", lambda: cleared.append(True))
+    with pytest.raises(CloudError) as exc:
+        discover_mod.run_discover("boss")
+    assert exc.value.details.get("resume_binding_paused") is True
+    assert exc.value.details.get("next_suggested") == "jobagent round start"
+    # The unusable binding is dropped so the next round start reselects.
+    assert cleared == [True]


### PR DESCRIPTION
Round start asks which confirmed resume delivers this round (always via interaction card); the binding rides the round into signed discovery so workbench applications record the exact resume revision. Stale bindings pause the platform for reselection. 1018 tests green.