### PR TITLE
fix(native): observation-limit recovery guidance and bind restart

### DIFF
--- a/src/jobagent/application/native_work.py
+++ b/src/jobagent/application/native_work.py
@@ -200,9 +200,16 @@ def present(work: dict[str, Any], *, execution: bool = False) -> dict[str, Any]:
             **unresolved["evidence"]}
     work["task"] = task
     can_execute = bool(execution and work.get("execution_permitted"))
+    # A read-only work that exhausted its observation attempts can no longer
+    # begin; its only settlement is a final receipt or explicit cancellation.
+    observation_locked = bool(not work.get("side_effect")
+                              and work.get("observation_attempts", 0) >= store.MAX_OBSERVATION_ATTEMPTS)
     reconcile = work.get("state") in {"intent_recorded", "reconcile_only"} and not can_execute
-    work["allowed_mode"] = "reconcile_only" if reconcile and work.get("side_effect") else (
-        "execute_once" if can_execute and work.get("side_effect") else "observe")
+    if work.get("side_effect"):
+        work["allowed_mode"] = "reconcile_only" if reconcile else (
+            "execute_once" if can_execute else "observe")
+    else:
+        work["allowed_mode"] = "reconcile_only" if observation_locked else "observe"
     result = work.get("result") or {}
     paused = bool(result.get("requires_user_action")) and not execution
     return {"ok": True, "event": "browser_work_required", "executor": EXECUTOR,
@@ -212,7 +219,7 @@ def present(work: dict[str, Any], *, execution: bool = False) -> dict[str, Any]:
             **({"user_prompt": _pause_prompt(result.get("reason"), result.get("evidence", {}).get("page_url") or ENTRY_URLS[work["binding"]["platform"]])} if paused else {}),
             "request_preserved": True,
             "next_suggested": (f"jobagent work submit --work-id {work['work_id']} --result <result.json>"
-                               if execution else f"jobagent work begin --work-id {work['work_id']}"),
+                               if execution or observation_locked else f"jobagent work begin --work-id {work['work_id']}"),
             "workflow": rounds.round_status()}
 
 
@@ -221,12 +228,23 @@ def _pause_prompt(reason: Any, url: str) -> str:
         return f"请在当前已绑定的 Chrome 页面 {url} 完成登录，完成后回复“登录好了”；不会新开另一套浏览器。"
     if reason in {"verification_required", "challenge"}:
         return f"当前平台要求安全验证，已暂停。请在同一 Chrome 页面 {url} 亲自完成验证后回复“验证好了”。"
+    if reason == "session_unknown":
+        return (f"无法唯一确认 Job Agent 应使用的 Chrome 窗口，已暂停。请关闭多余的 Chrome 窗口，"
+                f"只保留助手使用的这一个（相关页面 {url}），或让助手新开一个专用窗口；完成后回复“好了”。")
     return f"当前界面或宿主权限无法确认，已保留进度并暂停；请检查当前 Chrome 页面 {url} 或 Computer Use 权限，完成后回复“好了”。"
 
 
 def ensure_session(platform: str) -> dict[str, Any] | None:
     if _session():
         return None
+    # An explicit platform command restarting session work supersedes an
+    # earlier user-confirmed cancellation of that platform's bind task, and a
+    # closed bind task must not be re-presented as fresh work.
+    binding = _binding(platform)
+    active = rounds.ensure_current_round()
+    if active.get("native_cancelled_work", {}).get("platform") == platform:
+        del active["native_cancelled_work"]
+        rounds.save_round(active)
     task = {
         "instruction": "First verify native Computer Use is callable and app access is allowed. Inspect existing Chrome windows; reuse the existing Job Agent window/profile if uniquely identifiable. Bind that same window for login, search, details, delivery and receipts. If ambiguous, pause. Only if no reusable window exists may native UI open one. Do not copy cookies or clear profiles.",
         "required_evidence": ["native_computer_use_available=true", "browser=chrome", "window_reference", "profile_label", "group_reference", "observation", "reuse_status=reused|created_no_existing"],
@@ -234,7 +252,10 @@ def ensure_session(platform: str) -> dict[str, Any] | None:
             "window_reference": "observed stable window reference", "profile_label": "observed profile label",
             "group_reference": "observed task group reference", "reuse_status": "reused|created_no_existing"}},
     }
-    return present(store.ensure_work(action="bind_session", task=task, binding=_binding(platform)))
+    revision = len(store.list_work(binding))
+    work = store.ensure_work(action="bind_session", task=task, binding=binding,
+        key=f"bind:{active['round_id']}:{platform}:{revision}")
+    return present(work)
 
 
 def request_login(platform: str, *, diagnose: bool = False) -> dict[str, Any]:
@@ -492,7 +513,8 @@ def next_work() -> dict[str, Any]:
     if cancelled.get("platform") == platform:
         return {"ok": True, "event": "browser_work_cancelled", "requires_user_action": True,
                 "request_preserved": True, "work_id": cancelled["work_id"],
-                "user_prompt": "本平台的浏览器任务已按你的确认取消，未执行后续投递。若要结束本平台，请明确确认跳过；已有回执与本轮进度会保留。",
+                "user_prompt": (f"本平台的浏览器任务已按你的确认取消，未执行后续投递。若要结束本平台，请明确确认跳过；"
+                                f"若要恢复本平台，可重新运行 jobagent {platform} login。已有回执与本轮进度会保留。"),
                 "workflow": workflow, "next_suggested": "jobagent round status"}
     binding = _binding(platform)
     pending = store.pending_work(binding)

--- a/src/jobagent/infra/browser_work.py
+++ b/src/jobagent/infra/browser_work.py
@@ -30,18 +30,19 @@ _STATES = {"ready", "intent_recorded", "reconcile_only", "closed"}
 class BrowserWorkError(Exception):
     """A public-safe protocol failure that preserves existing work."""
 
-    def __init__(self, error: str, message: str):
+    def __init__(self, error: str, message: str, **extra: object):
         self.payload = {
             "ok": False,
             "error": error,
             "message": message,
             "request_preserved": True,
+            **extra,
         }
         super().__init__(message)
 
 
-def _error(error: str, message: str) -> BrowserWorkError:
-    return BrowserWorkError(error, message)
+def _error(error: str, message: str, **extra: object) -> BrowserWorkError:
+    return BrowserWorkError(error, message, **extra)
 
 
 def _canonical(value: object) -> str:
@@ -332,7 +333,12 @@ def begin_work(work_id, binding) -> dict:
             return _get(conn, work_id, binding)
         if not work["side_effect"] and work["observation_attempts"] >= MAX_OBSERVATION_ATTEMPTS:
             raise _error("browser_work_observation_limit",
-                         "The read-only observation limit was reached; preserve the current work.")
+                         "The read-only observation limit was reached; work begin is closed. "
+                         "A final verified observation receipt can still close this work with "
+                         "its preserved nonce, or cancel it explicitly.",
+                         work_id=work_id,
+                         next_suggested=f"jobagent work submit --work-id {work_id} --result <result.json>",
+                         cancel_command=f"jobagent work cancel --work-id {work_id} --confirm-cancel")
         nonce = work["nonce"] or secrets.token_urlsafe(32)
         attempts = work["observation_attempts"] + (0 if work["side_effect"] else 1)
         conn.execute("""

--- a/tests/test_browser_work.py
+++ b/tests/test_browser_work.py
@@ -227,7 +227,14 @@ def test_read_only_work_reobserves_boundedly_with_same_nonce(ledger, binding):
         paused = store.submit_work(work["work_id"], binding, receipt(
             started, receipt_id=f"pause-{attempt}", outcome="uncertain"))
         assert paused["state"] == "reconcile_only"
-    assert_error("browser_work_observation_limit", store.begin_work, work["work_id"], binding)
+    with pytest.raises(store.BrowserWorkError) as caught:
+        store.begin_work(work["work_id"], binding)
+    payload = caught.value.payload
+    assert payload["error"] == "browser_work_observation_limit"
+    assert payload["request_preserved"] is True
+    assert payload["work_id"] == work["work_id"]
+    assert payload["next_suggested"] == f"jobagent work submit --work-id {work['work_id']} --result <result.json>"
+    assert payload["cancel_command"] == f"jobagent work cancel --work-id {work['work_id']} --confirm-cancel"
     assert store.pending_work(binding)["execution_permitted"] is False
     # The observation limit does not prevent evidence already obtained arriving.
     done = store.submit_work(work["work_id"], binding, receipt(

--- a/tests/test_native_work.py
+++ b/tests/test_native_work.py
@@ -329,3 +329,58 @@ def test_capability_pause_schema_is_self_contained(env):
     sample["evidence"]["observation"] = "Native tool not available in synthetic host"
     paused = submit(env, work, sample)
     assert paused["requires_user_action"] and not state.load_json(state.current_round_path())["native_session"]
+
+
+def _pause_receipt(work, reason="session_unknown", attempt=0):
+    return {"receipt_id": f"{work['work_id']}-pause-{attempt}", "nonce": work["nonce"], "binding": work["binding"],
+            "outcome": "uncertain", "requires_user_action": True, "reason": reason,
+            "evidence": {"source": "host_ui_observation",
+                         "observed_at": datetime.now(timezone.utc).isoformat(),
+                         "observation": "Synthetic ambiguous Chrome windows; only a new tab identified"}}
+
+
+def _bind_receipt(work):
+    return {"receipt_id": work["work_id"] + "-final", "nonce": work["nonce"], "binding": work["binding"],
+            "outcome": "success",
+            "evidence": {"source": "host_ui_observation",
+                         "observed_at": datetime.now(timezone.utc).isoformat(),
+                         "observation": "Single synthetic Chrome window stably identified",
+                         "native_computer_use_available": True, "browser": "chrome",
+                         "window_reference": "chrome-window-9", "profile_label": "Profile 1",
+                         "group_reference": "Job Agent", "reuse_status": "created_no_existing"}}
+
+
+def test_observation_limit_recovery_still_accepts_final_receipt(env):
+    env.choose("boss", session=False)
+    response = native.request_login("boss")
+    work_id = response["work"]["work_id"]
+    assert response["work"]["action"] == "bind_session"
+    for attempt in range(store.MAX_OBSERVATION_ATTEMPTS):
+        begun = native.begin(work_id)["work"]
+        submit(env, begun, _pause_receipt(begun, attempt=attempt))
+    with pytest.raises(store.BrowserWorkError) as caught:
+        native.begin(work_id)
+    payload = caught.value.payload
+    assert payload["error"] == "browser_work_observation_limit"
+    assert payload["work_id"] == work_id
+    assert payload["next_suggested"].startswith("jobagent work submit")
+    assert payload["cancel_command"].startswith("jobagent work cancel")
+    status = native.request_login("boss")
+    assert status["next_suggested"].startswith("jobagent work submit")
+    assert status["work"]["allowed_mode"] == "reconcile_only"
+    assert "关闭多余的 Chrome 窗口" in status["user_prompt"]
+    submit(env, status["work"], _bind_receipt(status["work"]))
+    assert rounds.ensure_current_round()["native_session"]["window_reference"] == "chrome-window-9"
+
+
+def test_explicit_login_clears_cancelled_bind_marker(env):
+    env.choose("boss", session=False)
+    response = native.request_login("boss")
+    native.cancel(response["work"]["work_id"], confirmed=True)
+    cancelled = native.next_work()
+    assert cancelled["event"] == "browser_work_cancelled"
+    assert "jobagent boss login" in cancelled["user_prompt"]
+    resumed = native.request_login("boss")
+    assert resumed["event"] == "browser_work_required"
+    assert resumed["work"]["action"] == "bind_session"
+    assert native.next_work()["event"] == "browser_work_required"


### PR DESCRIPTION
## Customer incident

A customer's Boss `bind_session` exhausted its 3 read-only observation attempts (Chrome only showed a new-tab page). The CLI then kept steering the agent back into `work begin` — which raises `browser_work_observation_limit` with no recovery path — and the stale `native_cancelled_work` marker soft-locked the platform, so the only visible exit was cancel + skip Boss.

## Changes

1. **present()**: read-only work past `MAX_OBSERVATION_ATTEMPTS` reports `allowed_mode=reconcile_only` and `next_suggested=work submit` (final receipt with the preserved nonce still closes the work — covered by `test_read_only_work_reobserves_boundedly_with_same_nonce`).
2. **`browser_work_observation_limit`** error now carries `work_id`, `next_suggested` (submit path) and `cancel_command`.
3. **session_unknown pause prompt** is actionable: close extra Chrome windows / let the assistant open a dedicated one.
4. **Cancel soft-lock exit**: explicit platform login clears `native_cancelled_work` for that platform and mints a fresh bind work (revision key — the old keyless `ensure_work` returned the closed work forever); the cancelled notice now names both skip and resume paths.

No safety invariant changed: side-effect work still cannot be cancelled once issued; uncertain outcomes still reconcile.

## Verification

`pytest tests/` — 1020 passed (2 new tests: observation-limit end-to-end recovery incl. session binding; explicit-login clears the cancel marker and resumes `work next`).