### PR TITLE
feat: pre-delivery platform resume freshness gate (0.6.7)

### DIFF
--- a/src/jobagent/application/delivery.py
+++ b/src/jobagent/application/delivery.py
@@ -383,6 +383,22 @@ def send_reviewed(
             "next_suggested": next_suggested,
             "workflow": rounds.round_status(),
         }
+    # Pre-delivery resume freshness gate, mirroring the native send path.
+    from jobagent.application.resume_freshness import gate_delivery
+
+    gate = gate_delivery(
+        platform,
+        source={
+            "input_path": str(reviewed.get("source_path") or input_path or ""),
+            "preview_id": preview_id,
+            "authorization_id": authorization_id,
+            "limit": len(jobs),
+            "stop_on_failure": stop_on_failure,
+        },
+        dry_run=dry_run,
+    )
+    if gate is not None:
+        return gate
     emit_stage("delivery_started", platform=platform, total=len(jobs), dry_run=dry_run)
 
     def on_attempt(attempt, index: int, total: int) -> None:

--- a/src/jobagent/application/native_work.py
+++ b/src/jobagent/application/native_work.py
@@ -508,6 +508,14 @@ def next_work() -> dict[str, Any]:
     if workflow.get("workflow_complete") or not workflow.get("round_id"):
         return {"ok": True, "workflow": workflow, "next_suggested": workflow.get("next_suggested")}
     platform = workflow["current_platform"]
+    if platform is None:
+        # Every remaining platform is held by the resume freshness gate: the
+        # only forward path is answering its interaction, not issuing work.
+        return {"ok": True, "event": "browser_work_paused", "requires_user_action": True,
+                "request_preserved": True,
+                "message": "所有剩余平台都因简历新鲜度确认挂起；请先同步简历并应答恢复。",
+                "next_suggested": workflow.get("next_suggested") or "jobagent round status",
+                "workflow": workflow}
     active = rounds.ensure_current_round()
     cancelled = active.get("native_cancelled_work", {})
     if cancelled.get("platform") == platform:
@@ -556,6 +564,14 @@ def start_delivery(platform: str, *, input_path: str | None, preview_id: str | N
     if dry_run:
         return {"ok": True, "executor": EXECUTOR, "dry_run": True, "attempted": 0,
                 "reviewed_count": len(reviewed["send_candidates"]), "next_suggested": "jobagent work next"}
+    # Pre-delivery resume freshness gate: the platform sends the resume the
+    # user keeps in ITS backend, so a workbench update the user forgot to
+    # upload would be silently delivered as the old platform copy.
+    from jobagent.application.resume_freshness import gate_delivery
+
+    gate = gate_delivery(platform, source=source, dry_run=dry_run)
+    if gate is not None:
+        return gate
     active = rounds.ensure_current_round()
     existing = active["platforms"][platform].get("native_delivery")
     if existing and existing != source and store.pending_work(_binding(platform)):

--- a/src/jobagent/application/resume_freshness.py
+++ b/src/jobagent/application/resume_freshness.py
@@ -1,0 +1,517 @@
+"""投递前平台简历新鲜度门禁 (pre-delivery platform resume freshness gate).
+
+四平台的投递 = 浏览器触发平台自有动作，平台发送的是用户存在该平台后台的
+简历附件；工作台档案只用于分析，永不外发。若用户在工作台改了简历却忘了
+同步上传到平台后台，agent 触发投递时平台发出的就是旧简历，用户全程不知情。
+
+本模块在每个平台的投递动作触发前比较:
+  当前轮绑定简历的确认修订 (round ``resume_binding`` 快照)
+  vs 该平台上次投递确认时的基线 (``resume_freshness_baselines.json``)
+
+无基线或修订不一致 → 出一次三选项卡 (已同步 / 挂起本平台 / 整轮挂起);
+一致 → 静默直投。同一平台同一轮同一修订最多问一次：应答"已同步"即更新
+基线；绑定修订真实变更后的再次询问不属于重复打扰，正是本门禁要防的坑。
+
+设计文档 (权威): 私有 job-agent-server 仓
+docs/plans/2026-09-12-material-fallback-and-freshness-gate.md Part B。
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+from jobagent.infra import cloud_client
+from jobagent.infra.interaction_protocol import (
+    build_host_presentations,
+    build_interaction_required,
+)
+from jobagent.infra.interaction_state import (
+    clear_pending_interaction,
+    load_pending_interaction,
+    save_pending_interaction,
+)
+from jobagent.infra.rounds import FRESHNESS_HOLD_STATUS, round_status, set_platform_status, utc_now
+from jobagent.infra.state import current_round_path, load_json, resume_freshness_path, save_json
+
+INTERACTION_KIND = "resume_freshness"
+BASELINE_SCHEMA_VERSION = 1
+PLATFORM_LABELS = {"boss": "Boss 直聘", "liepin": "猎聘", "zhilian": "智联招聘", "51job": "前程无忧 51Job"}
+# 应答令牌: 卡片初始应答 A/B/C + B/C 挂起后的最终"传好了"应答共用 synced。
+CHOICE_SYNCED = "synced"
+CHOICE_PAUSE_PLATFORM = "pause_platform"
+CHOICE_PAUSE_ROUND = "pause_round"
+RESPOND_CHOICES = (CHOICE_SYNCED, CHOICE_PAUSE_PLATFORM, CHOICE_PAUSE_ROUND)
+_HOLD_STATES = {"platform_hold", "round_hold"}
+
+
+# ---------------------------------------------------------------- baselines
+
+
+def load_baselines() -> dict[str, Any]:
+    data = load_json(resume_freshness_path())
+    if not isinstance(data, dict) or not isinstance(data.get("platforms"), dict):
+        return {"schema_version": BASELINE_SCHEMA_VERSION, "platforms": {}}
+    return data
+
+
+def _fingerprint(binding: dict[str, Any]) -> dict[str, str]:
+    return {
+        "resume_id": str(binding.get("resume_id") or ""),
+        "resume_revision_id": str(binding.get("resume_revision_id") or ""),
+        "content_digest": str(binding.get("content_digest") or ""),
+        "confirmed_at": str(binding.get("confirmed_at") or ""),
+    }
+
+
+def _same_revision(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return bool(
+        left.get("resume_revision_id")
+        and left.get("resume_revision_id") == right.get("resume_revision_id")
+        and left.get("content_digest") == right.get("content_digest")
+    )
+
+
+def _save_baseline(platform: str, fingerprint: dict[str, Any]) -> None:
+    data = load_baselines()
+    data["platforms"][platform] = {**fingerprint, "updated_at": utc_now()}
+    save_json(resume_freshness_path(), data)
+
+
+def baseline_is_fresh(platform: str, binding: dict[str, Any]) -> bool:
+    """True when the platform baseline already matches the bound revision."""
+    baseline = load_baselines()["platforms"].get(platform)
+    return bool(baseline and _same_revision(baseline, _fingerprint(binding)))
+
+
+# ------------------------------------------------------------------- cards
+
+
+def _month_day(confirmed_at: Any) -> str:
+    from datetime import datetime
+
+    text = str(confirmed_at or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return "最近"
+    return f"{parsed.month} 月 {parsed.day} 日"
+
+
+def _interaction_id(round_id: str, platform: str, fingerprint: dict[str, Any]) -> str:
+    revision_tag = fingerprint["resume_revision_id"] or fingerprint["content_digest"]
+    return f"freshness:{round_id}:{platform}:{revision_tag}"
+
+
+def _respond_command(interaction_id: str, choice: str = CHOICE_SYNCED) -> str:
+    return f'jobagent interaction respond --interaction-id "{interaction_id}" --choice {choice}'
+
+
+def _build_card(platform: str, *, round_id: str, fingerprint: dict[str, Any], first_delivery: bool) -> dict[str, Any]:
+    label = PLATFORM_LABELS.get(platform, platform)
+    resume_name = fingerprint.get("resume_name") or "当前绑定简历"
+    date = _month_day(fingerprint.get("confirmed_at"))
+    if first_delivery:
+        prompt = (
+            f"本轮将首次通过 Job Agent 在 {label} 触发投递，{label} 发送的是你保存在其后台的简历附件。"
+            f"当前绑定简历《{resume_name}》（{date} 确认）已经上传到 {label} 后台了吗？"
+        )
+    else:
+        prompt = (
+            f"检测到你在 {date} 确认了新版本简历《{resume_name}》，本轮投递会触发 {label} "
+            f"发送你保存在其后台的简历。你已把这份最新简历同步上传到 {label} 后台了吗？"
+        )
+    return build_interaction_required(
+        interaction_id=_interaction_id(round_id, platform, fingerprint),
+        product_id="job_agent",
+        kind=INTERACTION_KIND,
+        title="平台简历新鲜度确认",
+        prompt=prompt,
+        fields=[
+            {
+                "field_id": "freshness_choice",
+                "type": "single",
+                "label": "同步状态",
+                "options": [
+                    {
+                        "option_id": CHOICE_SYNCED,
+                        "label": "已同步到该平台",
+                        "description": f"{label} 后台已是这份最新简历，继续触发投递",
+                    },
+                    {
+                        "option_id": CHOICE_PAUSE_PLATFORM,
+                        "label": "还没传，挂起本平台",
+                        "description": "本平台投递挂起，其余平台继续；同步完成后回来应答",
+                    },
+                    {
+                        "option_id": CHOICE_PAUSE_ROUND,
+                        "label": "还没传，整轮挂起",
+                        "description": "全轮暂停；同步完成后回来应答，按原顺序继续",
+                    },
+                ],
+            }
+        ],
+        fallback_text=(
+            f"请应答 {_respond_command(_interaction_id(round_id, platform, fingerprint))}："
+            "--choice synced（已同步）/ pause_platform（挂起本平台）/ pause_round（整轮挂起）。"
+        ),
+        continuation_action="jobagent.interaction.respond",
+        idempotency_key=_interaction_id(round_id, platform, fingerprint),
+    )
+
+
+def _send_command(platform: str, source: dict[str, Any]) -> str:
+    quoted = shlex.quote(str(source.get("input_path") or ""))
+    base = (
+        f"jobagent boss greet send --input {quoted}"
+        if platform == "boss"
+        else f"jobagent {platform} apply send --input {quoted}"
+    )
+    return (
+        f"{base} --preview-id {source.get('preview_id')} "
+        f"--authorization-id {source.get('authorization_id')} --limit {int(source.get('limit') or 100)}"
+    )
+
+
+# --------------------------------------------------------------- round help
+
+
+def _active_round() -> dict[str, Any] | None:
+    current = load_json(current_round_path())
+    if not current or current.get("status") != "active" or not current.get("round_id"):
+        return None
+    return current
+
+
+def _platform_record(active: dict[str, Any], platform: str) -> dict[str, Any] | None:
+    item = (active.get("platforms") or {}).get(platform)
+    record = (item or {}).get("resume_freshness") if isinstance(item, dict) else None
+    return record if isinstance(record, dict) else None
+
+
+def _save_record(platform: str, record: dict[str, Any] | None) -> dict[str, Any]:
+    active = _active_round()
+    if active is None:
+        return {"ok": False, "error": "round_not_started",
+                "message": "Start a Job Agent round before changing workflow state.",
+                "next_suggested": "jobagent round start"}
+    item = active.setdefault("platforms", {}).setdefault(platform, {"status": "pending"})
+    if record is None:
+        item.pop("resume_freshness", None)
+    else:
+        item["resume_freshness"] = record
+    if record is None and active.get("resume_freshness_round_hold", {}).get("platform") == platform:
+        active.pop("resume_freshness_round_hold", None)
+    from jobagent.infra.rounds import save_round
+
+    save_round(active)
+    return active
+
+
+def _set_status(platform: str, status: str, *, next_suggested: str, evidence_extra: dict[str, Any]) -> None:
+    active = _active_round() or {}
+    item = (active.get("platforms") or {}).get(platform) or {}
+    evidence = dict(item.get("evidence") or {})
+    evidence.update(evidence_extra)
+    set_platform_status(platform, status, command="jobagent interaction respond",
+                        evidence=evidence, next_suggested=next_suggested)
+
+
+def _gate_response(interaction: dict[str, Any], platform: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "error": "interaction_required",
+        "event": "resume_freshness_gate",
+        "platform": platform,
+        "interaction": interaction,
+        "host_presentations": build_host_presentations(interaction),
+        "requires_user_action": True,
+        "request_preserved": True,
+        "no_charge": True,
+        "message": "投递已暂停：请先确认平台后台的简历与工作台最新确认版本一致。",
+        "next_suggested": _respond_command(interaction["interaction_id"], CHOICE_SYNCED),
+        "workflow": round_status(),
+    }
+
+
+def _invalid_response(pending_or_record: dict[str, Any], message: str) -> dict[str, Any]:
+    interaction = pending_or_record.get("interaction") or {}
+    return {
+        "ok": False,
+        "error": "invalid_interaction_response",
+        "message": message,
+        "requires_user_action": True,
+        "interaction": interaction,
+        "host_presentations": build_host_presentations(interaction) if isinstance(interaction, dict) and interaction else None,
+        "next_suggested": _respond_command(str(pending_or_record.get("interaction_id") or "")),
+    }
+
+
+# --------------------------------------------------------------------- gate
+
+
+def gate_delivery(platform: str, *, source: dict[str, Any], dry_run: bool = False) -> dict[str, Any] | None:
+    """Return an interaction_required card when the platform resume may be stale.
+
+    Called right before a platform's delivery actions would be triggered (native
+    ``start_delivery`` and the legacy ``send_reviewed``). Returns None — silent
+    pass — for dry runs, unbound rounds, and platforms whose baseline already
+    matches the bound revision.
+    """
+    if dry_run or platform not in PLATFORM_LABELS:
+        return None
+    active = _active_round()
+    if active is None:
+        return None
+    binding = active.get("resume_binding") or {}
+    if not binding.get("id"):
+        return None
+    round_id = str(active["round_id"])
+    record = _platform_record(active, platform)
+    if record and record.get("round_id") == round_id:
+        state = str(record.get("state") or "")
+        if state == "awaiting":
+            # Same unanswered card for this round: re-present it idempotently.
+            save_pending_interaction(record["interaction"], stage=INTERACTION_KIND,
+                                     context={"platform": platform, "round_id": round_id})
+            return _gate_response(record["interaction"], platform)
+        if state in _HOLD_STATES:
+            return {
+                "ok": False,
+                "error": "resume_freshness_hold",
+                "platform": platform,
+                "requires_user_action": True,
+                "request_preserved": True,
+                "message": "该平台因简历新鲜度确认挂起：同步完成后应答 synced 恢复投递。",
+                "next_suggested": _respond_command(str(record.get("interaction_id") or "")),
+                "workflow": round_status(),
+            }
+    fingerprint = {**_fingerprint(binding), "resume_name": str(binding.get("resume_name") or "")}
+    if baseline_is_fresh(platform, binding):
+        return None
+    first_delivery = platform not in load_baselines()["platforms"]
+    interaction = _build_card(platform, round_id=round_id, fingerprint=fingerprint,
+                              first_delivery=first_delivery)
+    item = (active.get("platforms") or {}).get(platform) or {}
+    record = {
+        "interaction_id": interaction["interaction_id"],
+        "interaction": interaction,
+        "round_id": round_id,
+        "state": "awaiting",
+        "platform_label": PLATFORM_LABELS[platform],
+        "resume_binding_id": str(binding.get("id") or ""),
+        "resume_name": fingerprint["resume_name"],
+        "revision": _fingerprint(binding),
+        "pre_hold_status": str(item.get("status") or "reviewed"),
+        "source": {**source, "limit": int(source.get("limit") or 100)},
+        "asked_at": utc_now(),
+    }
+    from jobagent.infra.rounds import save_round
+
+    item = active.setdefault("platforms", {}).setdefault(platform, {"status": "pending"})
+    item["resume_freshness"] = record
+    save_round(active)
+    save_pending_interaction(interaction, stage=INTERACTION_KIND,
+                             context={"platform": platform, "round_id": round_id})
+    return _gate_response(interaction, platform)
+
+
+# ------------------------------------------------------------------ respond
+
+
+def respond(interaction_id: str, *, choice: str) -> dict[str, Any] | None:
+    """Answer a freshness card, or the final sync confirmation of a held platform.
+
+    Returns None when the id matches no freshness interaction so the CLI can
+    fall through to the other interaction handlers.
+    """
+    pending = load_pending_interaction()
+    if pending and str(pending.get("kind") or "") == INTERACTION_KIND \
+            and str(pending.get("interaction_id") or "") == interaction_id:
+        return _respond_initial(pending, interaction_id, choice)
+    # A held platform answers by id even when another platform's card has
+    # since taken the single pending-interaction slot: the hold itself lives
+    # in the round state, not in the slot.
+    active = _active_round()
+    if active is not None:
+        for platform, item in (active.get("platforms") or {}).items():
+            record = (item or {}).get("resume_freshness") if isinstance(item, dict) else None
+            if isinstance(record, dict) and str(record.get("interaction_id") or "") == interaction_id \
+                    and str(record.get("state") or "") in _HOLD_STATES:
+                return _respond_hold(platform, record, choice)
+    if pending and str(pending.get("kind") or "") == INTERACTION_KIND:
+        return {
+            "ok": False,
+            "error": "interaction_not_pending",
+            "message": "This freshness interaction is no longer waiting for that answer.",
+            "next_suggested": _respond_command(str(pending.get("interaction_id") or "")),
+        }
+    return None
+
+
+def _respond_initial(pending: dict[str, Any], interaction_id: str, choice: str) -> dict[str, Any]:
+    active = _active_round()
+    if active is None:
+        return _invalid_response(pending, "The delivery round is no longer active.")
+    context = pending.get("context") or {}
+    platform = str(context.get("platform") or "")
+    record = _platform_record(active, platform) if platform else None
+    if not record or str(record.get("interaction_id") or "") != interaction_id \
+            or str(record.get("round_id") or "") != str(active.get("round_id") or ""):
+        return _invalid_response(pending, "This freshness confirmation is no longer pending.")
+    if choice not in RESPOND_CHOICES:
+        return _invalid_response(pending, "Choose synced, pause_platform, or pause_round.")
+    if choice == CHOICE_SYNCED:
+        return _resolve_synced(platform, record, verified=None)
+    record["state"] = "platform_hold" if choice == CHOICE_PAUSE_PLATFORM else "round_hold"
+    record["hold_choice"] = choice
+    record["held_at"] = utc_now()
+    _save_record(platform, record)
+    if choice == CHOICE_PAUSE_ROUND:
+        active = _active_round() or {}
+        active["resume_freshness_round_hold"] = {
+            "platform": platform,
+            "interaction_id": interaction_id,
+            "held_at": utc_now(),
+        }
+        from jobagent.infra.rounds import save_round
+
+        save_round(active)
+    _set_status(platform, FRESHNESS_HOLD_STATUS,
+                next_suggested=_respond_command(interaction_id),
+                evidence_extra={"resume_freshness_hold": True, "interaction_id": interaction_id})
+    clear_pending_interaction()
+    message = (
+        "整轮已挂起：请把最新简历上传到平台后台，完成后回来应答 synced，按原顺序继续本轮。"
+        if choice == CHOICE_PAUSE_ROUND
+        else "本平台已挂起，其余平台继续：请把最新简历上传到平台后台，完成后回来应答 synced 恢复本平台投递。"
+    )
+    return {
+        "ok": True,
+        "event": "resume_freshness_platform_hold" if choice == CHOICE_PAUSE_PLATFORM else "resume_freshness_round_hold",
+        "platform": platform,
+        "requires_user_action": True,
+        "message": message,
+        "next_suggested": _respond_command(interaction_id),
+        "workflow": round_status(),
+    }
+
+
+def _respond_hold(platform: str, record: dict[str, Any], choice: str) -> dict[str, Any]:
+    if choice != CHOICE_SYNCED:
+        return _invalid_response(record, "This platform is already held; answer synced after uploading.")
+    try:
+        material = cloud_client.resume_binding_material(str(record.get("resume_binding_id") or ""))
+    except cloud_client.CloudError as exc:
+        if exc.code == "preparation_required":
+            # The bound resume changed underneath; same unwind as discover.
+            from jobagent.infra.rounds import clear_round_resume_binding
+
+            clear_round_resume_binding()
+            _save_record(platform, None)
+            _set_status(platform, str(record.get("pre_hold_status") or "reviewed"),
+                        next_suggested="jobagent round start",
+                        evidence_extra={"resume_freshness_hold": False})
+            return {
+                "ok": False,
+                "error": "resume_binding_paused",
+                "platform": platform,
+                "message": "绑定的简历已变更或不再可用，本平台挂起已解除。请重新执行 jobagent round start 选择简历后再继续。",
+                "next_suggested": "jobagent round start",
+            }
+        return {
+            "ok": False,
+            "error": "resume_freshness_recheck_unavailable",
+            "platform": platform,
+            "requires_user_action": True,
+            "request_preserved": True,
+            "retryable": bool(exc.retryable),
+            "message": "暂时无法复查工作台简历状态（网络或服务不可用），挂起保留。请稍后重新应答。",
+            "next_suggested": _respond_command(str(record.get("interaction_id") or "")),
+        }
+    snapshot = material.get("binding") or material.get("resume_binding") or {}
+    if _same_revision(snapshot, record.get("revision") or {}):
+        return _resolve_synced(platform, record, verified=snapshot)
+    # The user confirmed yet another revision while paused: keep the hold and
+    # re-anchor the comparison to the newest revision. No baseline update —
+    # the sync claim must match the CURRENT workbench revision to count.
+    record["revision"] = _fingerprint(snapshot)
+    record["resume_name"] = str(snapshot.get("resume_name") or record.get("resume_name") or "")
+    record["interaction"] = _build_card(platform, round_id=str(record.get("round_id") or ""),
+                                        fingerprint={**_fingerprint(snapshot),
+                                                     "resume_name": record["resume_name"]},
+                                        first_delivery=False)
+    record["interaction_id"] = record["interaction"]["interaction_id"]
+    record["reanchored_at"] = utc_now()
+    _save_record(platform, record)
+    date = _month_day((record.get("revision") or {}).get("confirmed_at"))
+    return {
+        "ok": False,
+        "error": "resume_freshness_changed_again",
+        "platform": platform,
+        "requires_user_action": True,
+        "request_preserved": True,
+        "message": (
+            f"复查发现你在 {date} 又确认了新版本简历《{record['resume_name']}》。"
+            "请把这份最新版本同步上传到平台后台后，再应答 synced 恢复投递。"
+        ),
+        "next_suggested": _respond_command(str(record.get("interaction_id") or "")),
+    }
+
+
+def _resolve_synced(platform: str, record: dict[str, Any], *, verified: dict[str, Any] | None) -> dict[str, Any]:
+    """User claims the platform now holds the bound revision: baseline + resume."""
+    fingerprint = _fingerprint(verified) if verified else dict(record.get("revision") or {})
+    if fingerprint.get("resume_revision_id"):
+        _save_baseline(platform, fingerprint)
+    _save_record(platform, None)
+    _set_status(platform, str(record.get("pre_hold_status") or "reviewed"),
+                next_suggested=_send_command(platform, record.get("source") or {}),
+                evidence_extra={
+                    "resume_freshness_hold": False,
+                    "resume_freshness_synced": True,
+                    "resume_revision_id": fingerprint.get("resume_revision_id"),
+                })
+    pending = load_pending_interaction()
+    if pending and str(pending.get("kind") or "") == INTERACTION_KIND:
+        clear_pending_interaction()
+    return {
+        "ok": True,
+        "event": "resume_freshness_synced",
+        "platform": platform,
+        "message": "已记录该平台的简历基线，恢复投递流程。",
+        "next_suggested": _send_command(platform, record.get("source") or {}),
+        "workflow": round_status(),
+    }
+
+
+# ------------------------------------------------------------------ cleanup
+
+
+def clear_hold(platform: str) -> None:
+    """Drop a platform's freshness hold (e.g. the user explicitly skips it)."""
+    active = _active_round()
+    if active is None:
+        return
+    record = _platform_record(active, platform)
+    if record is None:
+        return
+    _save_record(platform, None)
+    _set_status(platform, str(record.get("pre_hold_status") or "reviewed"),
+                next_suggested="jobagent round status",
+                evidence_extra={"resume_freshness_hold": False})
+    pending = load_pending_interaction()
+    if pending and str(pending.get("kind") or "") == INTERACTION_KIND \
+            and str(pending.get("interaction_id") or "") == str(record.get("interaction_id") or ""):
+        clear_pending_interaction()
+
+
+__all__ = [
+    "INTERACTION_KIND",
+    "RESPOND_CHOICES",
+    "baseline_is_fresh",
+    "clear_hold",
+    "gate_delivery",
+    "load_baselines",
+    "respond",
+]

--- a/src/jobagent/application/resume_freshness.py
+++ b/src/jobagent/application/resume_freshness.py
@@ -31,7 +31,13 @@ from jobagent.infra.interaction_state import (
     load_pending_interaction,
     save_pending_interaction,
 )
-from jobagent.infra.rounds import FRESHNESS_HOLD_STATUS, round_status, set_platform_status, utc_now
+from jobagent.infra.rounds import (
+    FRESHNESS_HOLD_STATUS,
+    TERMINAL_PLATFORM_STATUSES,
+    round_status,
+    set_platform_status,
+    utc_now,
+)
 from jobagent.infra.state import current_round_path, load_json, resume_freshness_path, save_json
 
 INTERACTION_KIND = "resume_freshness"
@@ -167,10 +173,13 @@ def _send_command(platform: str, source: dict[str, Any]) -> str:
         if platform == "boss"
         else f"jobagent {platform} apply send --input {quoted}"
     )
-    return (
+    command = (
         f"{base} --preview-id {source.get('preview_id')} "
         f"--authorization-id {source.get('authorization_id')} --limit {int(source.get('limit') or 100)}"
     )
+    if source.get("stop_on_failure") is False:
+        command += " --continue-on-failure"
+    return command
 
 
 # --------------------------------------------------------------- round help
@@ -355,6 +364,16 @@ def _respond_initial(pending: dict[str, Any], interaction_id: str, choice: str) 
         return _invalid_response(pending, "The delivery round is no longer active.")
     context = pending.get("context") or {}
     platform = str(context.get("platform") or "")
+    platform_status = str(((active.get("platforms") or {}).get(platform) or {}).get("status") or "")
+    terminal = platform_status in TERMINAL_PLATFORM_STATUSES
+    if terminal:
+        # The round already skipped or completed this platform while the card
+        # was still awaiting (e.g. round skip); a stale answer must not
+        # resurrect it or write a baseline. The dispatch guaranteed the
+        # pending slot holds this card, so clearing it is safe.
+        _save_record(platform, None)
+        clear_pending_interaction()
+        return _invalid_response(pending, "本轮该平台已结束（跳过或完成），无需再应答。")
     record = _platform_record(active, platform) if platform else None
     if not record or str(record.get("interaction_id") or "") != interaction_id \
             or str(record.get("round_id") or "") != str(active.get("round_id") or ""):
@@ -399,25 +418,41 @@ def _respond_initial(pending: dict[str, Any], interaction_id: str, choice: str) 
 
 def _respond_hold(platform: str, record: dict[str, Any], choice: str) -> dict[str, Any]:
     if choice != CHOICE_SYNCED:
-        return _invalid_response(record, "This platform is already held; answer synced after uploading.")
+        return _invalid_response(record, "本平台正处于挂起中；上传完成后请应答 synced。")
     try:
         material = cloud_client.resume_binding_material(str(record.get("resume_binding_id") or ""))
     except cloud_client.CloudError as exc:
-        if exc.code == "preparation_required":
-            # The bound resume changed underneath; same unwind as discover.
+        if exc.code in ("preparation_required", "resume_binding_not_found"):
+            # The bound resume changed underneath or the binding is gone; the
+            # same unwind discover.py performs. If the round was re-bound to a
+            # different resume while this hold lived, keep that new binding
+            # and release only the hold.
             from jobagent.infra.rounds import clear_round_resume_binding
 
-            clear_round_resume_binding()
+            active = _active_round() or {}
+            current_binding = active.get("resume_binding") or {}
+            still_bound = str(current_binding.get("id") or "") == str(record.get("resume_binding_id") or "")
+            if still_bound:
+                clear_round_resume_binding()
             _save_record(platform, None)
+            next_suggested = (
+                "jobagent round start"
+                if still_bound
+                else _send_command(platform, record.get("source") or {})
+            )
             _set_status(platform, str(record.get("pre_hold_status") or "reviewed"),
-                        next_suggested="jobagent round start",
+                        next_suggested=next_suggested,
                         evidence_extra={"resume_freshness_hold": False})
             return {
                 "ok": False,
                 "error": "resume_binding_paused",
                 "platform": platform,
-                "message": "绑定的简历已变更或不再可用，本平台挂起已解除。请重新执行 jobagent round start 选择简历后再继续。",
-                "next_suggested": "jobagent round start",
+                "message": (
+                    "绑定的简历已变更或不再可用，本平台挂起已解除。请重新执行 jobagent round start 选择简历后再继续。"
+                    if still_bound
+                    else "挂起期间本轮已改绑其他简历版本，挂起已解除；下次投递前会按新版本重新检查。"
+                ),
+                "next_suggested": next_suggested,
             }
         return {
             "ok": False,
@@ -430,33 +465,21 @@ def _respond_hold(platform: str, record: dict[str, Any], choice: str) -> dict[st
             "next_suggested": _respond_command(str(record.get("interaction_id") or "")),
         }
     snapshot = material.get("binding") or material.get("resume_binding") or {}
-    if _same_revision(snapshot, record.get("revision") or {}):
-        return _resolve_synced(platform, record, verified=snapshot)
-    # The user confirmed yet another revision while paused: keep the hold and
-    # re-anchor the comparison to the newest revision. No baseline update —
-    # the sync claim must match the CURRENT workbench revision to count.
-    record["revision"] = _fingerprint(snapshot)
-    record["resume_name"] = str(snapshot.get("resume_name") or record.get("resume_name") or "")
-    record["interaction"] = _build_card(platform, round_id=str(record.get("round_id") or ""),
-                                        fingerprint={**_fingerprint(snapshot),
-                                                     "resume_name": record["resume_name"]},
-                                        first_delivery=False)
-    record["interaction_id"] = record["interaction"]["interaction_id"]
-    record["reanchored_at"] = utc_now()
-    _save_record(platform, record)
-    date = _month_day((record.get("revision") or {}).get("confirmed_at"))
-    return {
-        "ok": False,
-        "error": "resume_freshness_changed_again",
-        "platform": platform,
-        "requires_user_action": True,
-        "request_preserved": True,
-        "message": (
-            f"复查发现你在 {date} 又确认了新版本简历《{record['resume_name']}》。"
-            "请把这份最新版本同步上传到平台后台后，再应答 synced 恢复投递。"
-        ),
-        "next_suggested": _respond_command(str(record.get("interaction_id") or "")),
-    }
+    if not _same_revision(snapshot, record.get("revision") or {}):
+        # A binding id is a frozen snapshot, so the server returning a
+        # different revision for the same id can only mean its semantics
+        # changed. Refuse to write a baseline for a revision this round's
+        # delivery was never based on; keep the hold for human review.
+        return {
+            "ok": False,
+            "error": "resume_freshness_revision_mismatch",
+            "platform": platform,
+            "requires_user_action": True,
+            "request_preserved": True,
+            "message": "复查返回的简历版本与本轮投递依据不一致，挂起保留。请执行 jobagent round status 核对绑定，或重新 jobagent round start。",
+            "next_suggested": "jobagent round status",
+        }
+    return _resolve_synced(platform, record, verified=snapshot)
 
 
 def _resolve_synced(platform: str, record: dict[str, Any], *, verified: dict[str, Any] | None) -> dict[str, Any]:
@@ -473,7 +496,10 @@ def _resolve_synced(platform: str, record: dict[str, Any], *, verified: dict[str
                     "resume_revision_id": fingerprint.get("resume_revision_id"),
                 })
     pending = load_pending_interaction()
-    if pending and str(pending.get("kind") or "") == INTERACTION_KIND:
+    if pending and str(pending.get("kind") or "") == INTERACTION_KIND \
+            and str(pending.get("interaction_id") or "") == str(record.get("interaction_id") or ""):
+        # Only our own card: another platform's awaiting freshness card may
+        # legitimately hold the single pending slot while this hold resolves.
         clear_pending_interaction()
     return {
         "ok": True,

--- a/src/jobagent/cli.py
+++ b/src/jobagent/cli.py
@@ -1805,8 +1805,9 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
                 "message": "Explicitly confirm skipping this platform for the current round.",
             }
         # An explicitly skipped platform is the escape hatch out of a resume
-        # freshness hold: drop its hold instead of asserting the turn (which
-        # the hold itself would reject).
+        # freshness card or hold: drop its record instead of asserting the
+        # turn (which the hold itself would reject) — otherwise a stale
+        # awaiting card could resurrect the skipped platform when answered.
         from jobagent.infra.rounds import FRESHNESS_HOLD_STATUS
         from jobagent.infra.state import current_round_path, load_json
 
@@ -1815,7 +1816,9 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
         owns_round_hold = (skip_state.get("resume_freshness_round_hold") or {}).get(
             "platform"
         ) == args.platform
-        if str(skip_item.get("status") or "") == FRESHNESS_HOLD_STATUS or owns_round_hold:
+        has_freshness_record = isinstance(skip_item.get("resume_freshness"), dict)
+        if str(skip_item.get("status") or "") == FRESHNESS_HOLD_STATUS or owns_round_hold \
+                or has_freshness_record:
             from jobagent.application.resume_freshness import clear_hold
 
             clear_hold(args.platform)

--- a/src/jobagent/cli.py
+++ b/src/jobagent/cli.py
@@ -133,6 +133,9 @@ def build_parser() -> argparse.ArgumentParser:
             "confirm_all",
             "exclude_jobs",
             "cancel_delivery",
+            "synced",
+            "pause_platform",
+            "pause_round",
         ],
     )
     interaction_respond.add_argument(
@@ -798,6 +801,14 @@ def _interaction_respond(args: argparse.Namespace) -> dict[str, Any]:
 
     interaction_id = str(args.interaction_id or "").strip()
     pending = load_pending_interaction()
+    # 投递前平台简历新鲜度门禁的应答（含挂起后按 id 应答的最终 synced）。
+    # 该门禁的挂起态记在轮次里，即使 pending 槽位已被其他平台的卡占用，
+    # 也必须能按 interaction-id 应答，所以这里无条件先走一次。
+    from jobagent.application.resume_freshness import respond as respond_freshness
+
+    freshness = respond_freshness(interaction_id, choice=str(args.choice or ""))
+    if freshness is not None:
+        return freshness
     if pending and str(pending.get("kind") or "").startswith("delivery_"):
         if str(pending.get("interaction_id") or "") != interaction_id:
             return {
@@ -1793,7 +1804,23 @@ def _dispatch_unlocked(args: argparse.Namespace) -> dict[str, Any]:
                 "platform": args.platform,
                 "message": "Explicitly confirm skipping this platform for the current round.",
             }
-        assert_platform_turn(args.platform)
+        # An explicitly skipped platform is the escape hatch out of a resume
+        # freshness hold: drop its hold instead of asserting the turn (which
+        # the hold itself would reject).
+        from jobagent.infra.rounds import FRESHNESS_HOLD_STATUS
+        from jobagent.infra.state import current_round_path, load_json
+
+        skip_state = load_json(current_round_path()) or {}
+        skip_item = (skip_state.get("platforms") or {}).get(args.platform) or {}
+        owns_round_hold = (skip_state.get("resume_freshness_round_hold") or {}).get(
+            "platform"
+        ) == args.platform
+        if str(skip_item.get("status") or "") == FRESHNESS_HOLD_STATUS or owns_round_hold:
+            from jobagent.application.resume_freshness import clear_hold
+
+            clear_hold(args.platform)
+        else:
+            assert_platform_turn(args.platform)
         set_platform_status(args.platform, "skipped_this_round", command="jobagent round skip")
         return {"ok": True, "platform": args.platform, "workflow": round_status()}
 

--- a/src/jobagent/infra/account_state.py
+++ b/src/jobagent/infra/account_state.py
@@ -24,6 +24,7 @@ _ACCOUNT_OWNED_PATHS = (
     "current_round.json",
     "pending_interaction.json",
     "pending_round_binding.json",
+    "resume_freshness_baselines.json",
     "rounds",
     "discoveries",
     "archive",

--- a/src/jobagent/infra/rounds.py
+++ b/src/jobagent/infra/rounds.py
@@ -11,6 +11,10 @@ from jobagent.infra.state import current_round_path, rounds_dir, save_json, load
 
 DEFAULT_PLATFORM_ORDER = ["boss", "liepin", "zhilian", "51job"]
 TERMINAL_PLATFORM_STATUSES = {"completed", "skipped_this_round"}
+# A platform paused by the pre-delivery resume freshness gate. It is not
+# terminal (the round is not complete while it is held) but it must not be
+# picked as the current platform: the agent continues later platforms.
+FRESHNESS_HOLD_STATUS = "resume_freshness_hold"
 ROUND_SCHEMA_VERSION = 4
 DEFAULT_BROWSER_EXECUTOR = "codex_native"
 UNBOUND_BROWSER_SESSION = "native-unbound"
@@ -338,9 +342,47 @@ def _round_current_platform(state: dict[str, Any]) -> str | None:
     platforms = state.get("platforms") or {}
     for platform in state.get("platform_order") or DEFAULT_PLATFORM_ORDER:
         status = str((platforms.get(platform) or {}).get("status") or "pending")
+        if status == FRESHNESS_HOLD_STATUS:
+            continue
         if status not in TERMINAL_PLATFORM_STATUSES:
             return platform
     return None
+
+
+def _freshness_view(state: dict[str, Any], platforms: dict[str, Any], order: list[str]) -> dict[str, Any]:
+    """Summarize resume-freshness holds for round_status/assert_platform_turn."""
+    held = [
+        platform
+        for platform in order
+        if str((platforms.get(platform) or {}).get("status") or "pending") == FRESHNESS_HOLD_STATUS
+    ]
+    round_hold = state.get("resume_freshness_round_hold")
+    return {
+        "round_hold": round_hold if isinstance(round_hold, dict) else None,
+        "held_platforms": held,
+    }
+
+
+def _freshness_next_suggested(view: dict[str, Any], platforms: dict[str, Any]) -> str | None:
+    """Point the user at the pending freshness respond command, if any."""
+    record = None
+    platform = None
+    hold = view.get("round_hold") or {}
+    if hold.get("platform"):
+        platform = str(hold["platform"])
+        record = ((platforms.get(platform) or {}).get("resume_freshness") or {})
+    if not record:
+        for candidate in view.get("held_platforms") or []:
+            record = (platforms.get(candidate) or {}).get("resume_freshness") or {}
+            if record.get("interaction_id"):
+                platform = candidate
+                break
+    interaction_id = str((record or {}).get("interaction_id") or "")
+    if not interaction_id:
+        return None
+    return (
+        f'jobagent interaction respond --interaction-id "{interaction_id}" --choice synced'
+    )
 
 
 def _login_receipt_is_recent(
@@ -631,7 +673,15 @@ def round_status() -> dict[str, Any]:
         state["status"] = "completed"
         if not migration_deferred:
             save_round(state)
-    current_platform = remaining[0] if remaining else None
+    freshness = _freshness_view(state, platforms, order)
+    current_platform = next(
+        (
+            platform
+            for platform in remaining
+            if str(platforms.get(platform, {}).get("status") or "pending") != FRESHNESS_HOLD_STATUS
+        ),
+        None,
+    )
     next_suggested = None
     if current_platform:
         item = platforms.get(current_platform, {})
@@ -645,6 +695,12 @@ def round_status() -> dict[str, Any]:
             current_platform,
             str(item.get("status") or "pending"),
         )
+    if freshness.get("round_hold"):
+        # The whole round is held: the respond command is the only forward
+        # path, so it outranks the current platform's own next command.
+        next_suggested = _freshness_next_suggested(freshness, platforms) or next_suggested
+    if next_suggested is None:
+        next_suggested = _freshness_next_suggested(freshness, platforms)
     return {
         "round_id": state.get("round_id"),
         "status": "completed" if workflow_complete else "active",
@@ -662,6 +718,7 @@ def round_status() -> dict[str, Any]:
         "intent": state.get("intent"),
         "resume_binding": state.get("resume_binding"),
         "profile_reconciliation": state.get("profile_reconciliation"),
+        "resume_freshness": freshness,
         "platforms": platforms,
         "current_platform": current_platform,
         "remaining_platforms": remaining,
@@ -709,6 +766,37 @@ def assert_platform_turn(platform: str) -> dict[str, Any]:
                 "message": "The previous round is complete. Start a new round explicitly.",
                 "requested_platform": platform,
                 "next_suggested": "jobagent round start",
+                "workflow": workflow,
+            }
+        )
+    freshness = workflow.get("resume_freshness") or {}
+    round_hold = freshness.get("round_hold") or None
+    if round_hold:
+        raise RoundOrderError(
+            {
+                "ok": False,
+                "error": "round_resume_freshness_hold",
+                "message": (
+                    "本轮因平台简历新鲜度确认整轮挂起：请先把最新简历同步上传到对应平台后台，"
+                    "完成后应答 synced 恢复，再按原顺序继续本轮。"
+                ),
+                "requested_platform": platform,
+                "held_platform": round_hold.get("platform"),
+                "next_suggested": _freshness_next_suggested(freshness, workflow["platforms"]),
+                "workflow": workflow,
+            }
+        )
+    if platform in (freshness.get("held_platforms") or []):
+        raise RoundOrderError(
+            {
+                "ok": False,
+                "error": "platform_resume_freshness_hold",
+                "message": (
+                    "该平台因简历新鲜度确认挂起：请先把最新简历同步上传到该平台后台，"
+                    "完成后应答 synced 恢复投递。"
+                ),
+                "requested_platform": platform,
+                "next_suggested": _freshness_next_suggested(freshness, workflow["platforms"]),
                 "workflow": workflow,
             }
         )

--- a/src/jobagent/infra/state.py
+++ b/src/jobagent/infra/state.py
@@ -74,6 +74,11 @@ def pending_interaction_path() -> Path:
     return STATE_DIR / "pending_interaction.json"
 
 
+def resume_freshness_path() -> Path:
+    ensure_dirs()
+    return STATE_DIR / "resume_freshness_baselines.json"
+
+
 def rounds_dir() -> Path:
     ensure_dirs()
     ROUNDS_DIR.mkdir(parents=True, exist_ok=True)

--- a/tests/test_resume_freshness.py
+++ b/tests/test_resume_freshness.py
@@ -15,9 +15,10 @@ PLATFORMS = ["boss", "liepin", "zhilian", "51job"]
 
 
 def binding_fixture(revision="rev-1", digest="sha256:aaa", name="后端简历",
-                    confirmed_at="2026-09-08T10:00:00+00:00", resume_id="res-1"):
+                    confirmed_at="2026-09-08T10:00:00+00:00", resume_id="res-1",
+                    binding_id="bind-1"):
     return {
-        "id": "bind-1",
+        "id": binding_id,
         "context_id": "ctx-1",
         "resume_id": resume_id,
         "resume_revision_id": revision,
@@ -273,14 +274,40 @@ def test_round_hold_resumes_in_original_order(fresh_env, monkeypatch):
 # ------------------------------------------------- B/C respond re-checks
 
 
-def test_hold_respond_rechecks_workbench_and_reanchors(fresh_env, monkeypatch):
+@pytest.mark.parametrize("hold_choice", ["pause_platform", "pause_round"])
+def test_held_platform_rejects_non_synced_answers(fresh_env, monkeypatch, hold_choice):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice=hold_choice)
+    # Any leak past the guard would hit the cloud recheck and fail loudly.
+    monkeypatch.setattr(
+        freshness.cloud_client, "resume_binding_material",
+        lambda binding_id: pytest.fail("non-synced answers must not reach the recheck"),
+    )
+    result = freshness.respond(interaction_id, choice=hold_choice)
+    assert result["ok"] is False and result["error"] == "invalid_interaction_response"
+    assert "boss" not in freshness.load_baselines()["platforms"]
+    workflow = rounds_mod.round_status()
+    assert workflow["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
+    round_hold = workflow["resume_freshness"]["round_hold"]
+    if hold_choice == "pause_round":
+        assert round_hold is not None
+    else:
+        assert round_hold is None
+
+
+def test_hold_respond_revision_mismatch_refuses_without_baseline(fresh_env, monkeypatch):
     platforms = {p: {"status": "pending"} for p in PLATFORMS}
     platforms["boss"] = {"status": "reviewed"}
     write_round(binding_fixture())
     card = freshness.gate_delivery("boss", source=source_fixture())
     interaction_id = card["interaction"]["interaction_id"]
     freshness.respond(interaction_id, choice="pause_platform")
-    # The user confirmed yet another revision while uploading.
+    # Binding ids are frozen snapshots; a different revision for the same id
+    # can only mean server semantics changed. The gate must refuse.
     monkeypatch.setattr(
         freshness.cloud_client,
         "resume_binding_material",
@@ -292,19 +319,9 @@ def test_hold_respond_rechecks_workbench_and_reanchors(fresh_env, monkeypatch):
         },
     )
     result = freshness.respond(interaction_id, choice="synced")
-    assert result["ok"] is False and result["error"] == "resume_freshness_changed_again"
-    assert "9 月 11 日" in result["message"]
-    # No baseline was written and the platform stays held, re-anchored.
+    assert result["ok"] is False and result["error"] == "resume_freshness_revision_mismatch"
     assert "boss" not in freshness.load_baselines()["platforms"]
-    workflow = rounds_mod.round_status()
-    assert workflow["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
-    record = workflow["platforms"]["boss"]["resume_freshness"]
-    assert record["revision"]["resume_revision_id"] == "rev-9"
-    assert record["interaction_id"] != interaction_id
-    # Answering the re-anchored id against the same revision resolves.
-    result = freshness.respond(record["interaction_id"], choice="synced")
-    assert result["ok"] is True
-    assert freshness.load_baselines()["platforms"]["boss"]["resume_revision_id"] == "rev-9"
+    assert rounds_mod.round_status()["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
 
 
 def test_hold_respond_material_unavailable_keeps_hold(fresh_env, monkeypatch):
@@ -495,3 +512,133 @@ def test_cli_interaction_respond_dispatches_freshness(fresh_env):
     result = _dispatch(args)
     assert result["ok"] is True and result["event"] == "resume_freshness_synced"
     assert freshness.load_baselines()["platforms"]["boss"]["resume_revision_id"] == "rev-1"
+
+
+def test_send_command_preserves_continue_on_failure(fresh_env, monkeypatch):
+    from jobagent.application.resume_freshness import _send_command
+
+    source = source_fixture()
+    assert "--continue-on-failure" not in _send_command("boss", source)
+    source["stop_on_failure"] = False
+    assert _send_command("boss", source).endswith("--continue-on-failure")
+
+
+def test_hold_respond_unwind_keeps_rebound_binding(fresh_env, monkeypatch):
+    from jobagent.infra.cloud_client import CloudError
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+    # While the hold lived, the round re-bound to a different resume binding.
+    rebound = binding_fixture(revision="rev-8", digest="sha256:other", binding_id="bind-2")
+    active = state_mod.load_json(state_mod.current_round_path())
+    active["resume_binding"] = rebound
+    state_mod.save_json(state_mod.current_round_path(), active)
+    monkeypatch.setattr(
+        freshness.cloud_client, "resume_binding_material",
+        lambda binding_id: (_ for _ in ()).throw(
+            CloudError("preparation required", status=409, code="preparation_required")),
+    )
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "resume_binding_paused"
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert active.get("resume_binding") == rebound  # new binding intact
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert "--preview-id preview-1" in result["next_suggested"]
+
+
+def test_hold_respond_binding_not_found_unwinds(fresh_env, monkeypatch):
+    from jobagent.infra.cloud_client import CloudError
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+    monkeypatch.setattr(
+        freshness.cloud_client, "resume_binding_material",
+        lambda binding_id: (_ for _ in ()).throw(
+            CloudError("binding gone", status=404, code="resume_binding_not_found")),
+    )
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "resume_binding_paused"
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert not active.get("resume_binding")
+
+
+def test_resolving_one_hold_preserves_another_awaiting_card(fresh_env, monkeypatch):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    platforms["liepin"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    boss_card = freshness.gate_delivery("boss", source=source_fixture())
+    boss_id = boss_card["interaction"]["interaction_id"]
+    freshness.respond(boss_id, choice="pause_platform")
+    # The agent continues; liepin's gate takes the single pending slot.
+    liepin_card = freshness.gate_delivery("liepin", source=source_fixture())
+    liepin_id = liepin_card["interaction"]["interaction_id"]
+    pending = load_pending_interaction()
+    assert pending is not None and pending["interaction_id"] == liepin_id
+    # Resolving boss's hold by id must not evict liepin's awaiting card.
+    monkeypatch.setattr(
+        freshness.cloud_client,
+        "resume_binding_material",
+        lambda binding_id: {"binding": binding_fixture(), "profile": {}, "profile_digest": "d"},
+    )
+    result = freshness.respond(boss_id, choice="synced")
+    assert result["ok"] is True
+    pending = load_pending_interaction()
+    assert pending is not None and pending["interaction_id"] == liepin_id
+    # Liepin's card still answers normally afterwards.
+    result = freshness.respond(liepin_id, choice="synced")
+    assert result["ok"] is True and result["event"] == "resume_freshness_synced"
+
+
+def test_round_skip_clears_awaiting_card_and_stale_answer_is_rejected(fresh_env):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    # The CLI skip path: clear the awaiting record, then mark the platform skipped.
+    freshness.clear_hold("boss")
+    rounds_mod.set_platform_status("boss", "skipped_this_round", command="jobagent round skip")
+    assert load_pending_interaction() is None
+    # No freshness handler claims the stale id anymore.
+    assert freshness.respond(interaction_id, choice="synced") is None
+    assert "boss" not in freshness.load_baselines()["platforms"]
+    # Defense in depth: a stale card that somehow still occupies the slot on a
+    # terminal platform is rejected instead of resurrecting the platform.
+    from jobagent.infra.interaction_state import save_pending_interaction
+
+    save_pending_interaction(card["interaction"], stage=freshness.INTERACTION_KIND,
+                             context={"platform": "boss", "round_id": "r-1"})
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "invalid_interaction_response"
+    assert load_pending_interaction() is None
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert active["platforms"]["boss"]["status"] == "skipped_this_round"
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert "boss" not in freshness.load_baselines()["platforms"]
+
+
+def test_cli_round_skip_dispatch_clears_awaiting_card(fresh_env):
+    from jobagent.cli import _dispatch, build_parser
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    parser = build_parser()
+    args = parser.parse_args(["round", "skip", "--platform", "boss", "--confirm-skip"])
+    result = _dispatch(args)
+    assert result["ok"] is True
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert active["platforms"]["boss"]["status"] == "skipped_this_round"
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert load_pending_interaction() is None

--- a/tests/test_resume_freshness.py
+++ b/tests/test_resume_freshness.py
@@ -1,0 +1,497 @@
+"""投递前平台简历新鲜度门禁 — 设计文档 Part B (2026-09-12) 的行为测试。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from jobagent.application import resume_freshness as freshness
+from jobagent.infra import rounds as rounds_mod
+from jobagent.infra import state as state_mod
+from jobagent.infra.interaction_state import load_pending_interaction
+
+PLATFORMS = ["boss", "liepin", "zhilian", "51job"]
+
+
+def binding_fixture(revision="rev-1", digest="sha256:aaa", name="后端简历",
+                    confirmed_at="2026-09-08T10:00:00+00:00", resume_id="res-1"):
+    return {
+        "id": "bind-1",
+        "context_id": "ctx-1",
+        "resume_id": resume_id,
+        "resume_revision_id": revision,
+        "content_digest": digest,
+        "target_role": "Engineer",
+        "resume_name": name,
+        "confirmed_at": confirmed_at,
+        "resume_revision_number": 2,
+    }
+
+
+@pytest.fixture
+def fresh_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(state_mod, "STATE_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(state_mod, "ROUNDS_DIR", tmp_path / "rounds", raising=False)
+    from jobagent.infra import account_state
+
+    monkeypatch.setattr(account_state, "current_account_ref", lambda **kwargs: "acct_fresh")
+    yield tmp_path
+
+
+def write_round(binding, *, platforms=None, round_id="r-1", extra=None):
+    state = {
+        "schema_version": rounds_mod.ROUND_SCHEMA_VERSION,
+        "round_id": round_id,
+        "status": "active",
+        "created_at": "2026-09-12T08:00:00+00:00",
+        "updated_at": "2026-09-12T08:00:00+00:00",
+        "platform_order": list(PLATFORMS),
+        "platforms": platforms
+        or {platform: {"status": "pending"} for platform in PLATFORMS},
+        "resume_binding": binding,
+    }
+    if extra:
+        state.update(extra)
+    state_mod.save_json(state_mod.current_round_path(), state)
+    return state
+
+
+def set_baseline(platform, *, revision="rev-1", digest="sha256:aaa",
+                 resume_id="res-1", confirmed_at="2026-09-01T00:00:00+00:00"):
+    data = freshness.load_baselines()
+    data["platforms"][platform] = {
+        "resume_id": resume_id,
+        "resume_revision_id": revision,
+        "content_digest": digest,
+        "confirmed_at": confirmed_at,
+        "updated_at": "2026-09-12T00:00:00+00:00",
+    }
+    state_mod.save_json(state_mod.resume_freshness_path(), data)
+
+
+def source_fixture():
+    return {
+        "input_path": "/tmp/reviewed.json",
+        "preview_id": "preview-1",
+        "authorization_id": "auth-1",
+        "limit": 100,
+        "stop_on_failure": True,
+    }
+
+
+# ------------------------------------------------------------ detection
+
+
+def test_fresh_baseline_is_silent(fresh_env):
+    write_round(binding_fixture())
+    set_baseline("boss")
+    assert freshness.gate_delivery("boss", source=source_fixture()) is None
+    # No gate record was created and no pending interaction occupies the slot.
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert load_pending_interaction() is None
+
+
+def test_no_baseline_first_delivery_asks_once(fresh_env):
+    write_round(binding_fixture(), platforms={p: {"status": "pending"} for p in PLATFORMS})
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    assert card is not None and card["error"] == "interaction_required"
+    interaction = card["interaction"]
+    assert interaction["kind"] == freshness.INTERACTION_KIND
+    assert "首次" in interaction["prompt"] and "Boss 直聘" in interaction["prompt"]
+    options = interaction["fields"][0]["options"]
+    assert [option["option_id"] for option in options] == ["synced", "pause_platform", "pause_round"]
+    pending = load_pending_interaction()
+    assert pending and pending["stage"] == freshness.INTERACTION_KIND
+
+
+def test_changed_revision_cards_with_date_anchor(fresh_env):
+    write_round(binding_fixture())
+    set_baseline("boss", revision="rev-0", digest="sha256:old")
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    prompt = card["interaction"]["prompt"]
+    assert "9 月 8 日" in prompt and "后端简历" in prompt and "Boss 直聘" in prompt
+    assert "首次" not in prompt
+
+
+def test_unbound_round_and_dry_run_are_silent(fresh_env):
+    write_round(None)
+    assert freshness.gate_delivery("boss", source=source_fixture()) is None
+    write_round(binding_fixture())
+    assert freshness.gate_delivery("boss", source=source_fixture(), dry_run=True) is None
+
+
+def test_gate_is_idempotent_while_awaiting(fresh_env):
+    write_round(binding_fixture())
+    first = freshness.gate_delivery("boss", source=source_fixture())
+    second = freshness.gate_delivery("boss", source=source_fixture())
+    assert second["interaction"]["interaction_id"] == first["interaction"]["interaction_id"]
+
+
+# ------------------------------------------------------------- option A
+
+
+def test_choice_synced_updates_baseline_and_restores_flow(fresh_env):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {
+        "status": "reviewed",
+        "evidence": {"discover_id": "d-1", "preview_id": "preview-1", "authorization_id": "auth-1"},
+    }
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    result = freshness.respond(card["interaction"]["interaction_id"], choice="synced")
+    assert result["ok"] is True and result["event"] == "resume_freshness_synced"
+    assert "apply send" in result["next_suggested"] or "greet send" in result["next_suggested"]
+    assert "--preview-id preview-1" in result["next_suggested"]
+    baseline = freshness.load_baselines()["platforms"]["boss"]
+    assert baseline["resume_revision_id"] == "rev-1" and baseline["content_digest"] == "sha256:aaa"
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert active["platforms"]["boss"]["status"] == "reviewed"
+    assert load_pending_interaction() is None
+    # Same revision in the same round: silent now and forever after.
+    assert freshness.gate_delivery("boss", source=source_fixture()) is None
+
+
+def test_same_round_new_revision_asks_again(fresh_env):
+    write_round(binding_fixture())
+    set_baseline("boss", revision="rev-0", digest="sha256:old")
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    freshness.respond(card["interaction"]["interaction_id"], choice="synced")
+    # A genuinely newer confirmed revision mid-round is a new question.
+    write_round(binding_fixture(revision="rev-2", digest="sha256:bbb"))
+    again = freshness.gate_delivery("boss", source=source_fixture())
+    assert again is not None
+    assert again["interaction"]["interaction_id"] != card["interaction"]["interaction_id"]
+
+
+# --------------------------------------------------------- options B and C
+
+
+def test_pause_platform_holds_only_that_platform(fresh_env):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed", "evidence": {"discover_id": "d-1"}}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    result = freshness.respond(interaction_id, choice="pause_platform")
+    assert result["ok"] is True and result["event"] == "resume_freshness_platform_hold"
+    workflow = rounds_mod.round_status()
+    assert workflow["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
+    assert workflow["current_platform"] == "liepin"
+    assert workflow["resume_freshness"]["held_platforms"] == ["boss"]
+    assert workflow["resume_freshness"]["round_hold"] is None
+    assert load_pending_interaction() is None
+    # Other platforms keep working; the held one is rejected with a pointer.
+    rounds_mod.assert_platform_turn("liepin")
+    with pytest.raises(rounds_mod.RoundOrderError) as exc:
+        rounds_mod.assert_platform_turn("boss")
+    assert exc.value.payload["error"] == "platform_resume_freshness_hold"
+    assert interaction_id in exc.value.payload["next_suggested"]
+
+
+def test_hold_answers_by_id_even_when_slot_is_taken(fresh_env, monkeypatch):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+    # Liepin's own delivery confirmation card later overwrites the slot.
+    from jobagent.infra.interaction_state import save_pending_interaction
+
+    save_pending_interaction(
+        {
+            "interaction_id": "liepin-card",
+            "kind": "delivery_confirmation",
+            "title": "t",
+            "prompt": "p",
+            "fallback_text": "f",
+            "fields": [{"field_id": "x", "type": "single", "label": "l",
+                        "options": [{"option_id": "confirm_all", "label": "y"}]}],
+        },
+        stage="delivery_choice",
+    )
+    snapshot = binding_fixture()
+    monkeypatch.setattr(
+        freshness.cloud_client,
+        "resume_binding_material",
+        lambda binding_id: {"binding": snapshot, "profile": {}, "profile_digest": "d"},
+    )
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is True
+    assert freshness.load_baselines()["platforms"]["boss"]["resume_revision_id"] == "rev-1"
+    workflow = rounds_mod.round_status()
+    assert workflow["platforms"]["boss"]["status"] == "reviewed"
+    assert workflow["current_platform"] == "boss"
+
+
+def test_pause_round_blocks_the_whole_round(fresh_env):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    result = freshness.respond(interaction_id, choice="pause_round")
+    assert result["ok"] is True and result["event"] == "resume_freshness_round_hold"
+    workflow = rounds_mod.round_status()
+    assert workflow["resume_freshness"]["round_hold"]["platform"] == "boss"
+    assert workflow["resume_freshness"]["held_platforms"] == ["boss"]
+    with pytest.raises(rounds_mod.RoundOrderError) as exc:
+        rounds_mod.assert_platform_turn("liepin")
+    assert exc.value.payload["error"] == "round_resume_freshness_hold"
+    # next_suggested points at the respond command while everything is held.
+    assert interaction_id in workflow["next_suggested"] or "interaction respond" in workflow["next_suggested"]
+
+
+def test_round_hold_resumes_in_original_order(fresh_env, monkeypatch):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_round")
+    monkeypatch.setattr(
+        freshness.cloud_client,
+        "resume_binding_material",
+        lambda binding_id: {"binding": binding_fixture(), "profile": {}, "profile_digest": "d"},
+    )
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is True
+    workflow = rounds_mod.round_status()
+    assert workflow["resume_freshness"]["round_hold"] is None
+    assert workflow["platforms"]["boss"]["status"] == "reviewed"
+    assert workflow["current_platform"] == "boss"
+    rounds_mod.assert_platform_turn("boss")  # the held platform resumes its turn
+    with pytest.raises(rounds_mod.RoundOrderError) as exc:
+        rounds_mod.assert_platform_turn("liepin")
+    # Liepin is blocked by ordinary ordering now, not by the freshness hold.
+    assert exc.value.payload["error"] == "platform_out_of_order"
+
+
+# ------------------------------------------------- B/C respond re-checks
+
+
+def test_hold_respond_rechecks_workbench_and_reanchors(fresh_env, monkeypatch):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture())
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+    # The user confirmed yet another revision while uploading.
+    monkeypatch.setattr(
+        freshness.cloud_client,
+        "resume_binding_material",
+        lambda binding_id: {
+            "binding": binding_fixture(revision="rev-9", digest="sha256:new",
+                                       confirmed_at="2026-09-11T09:30:00+00:00"),
+            "profile": {},
+            "profile_digest": "d",
+        },
+    )
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "resume_freshness_changed_again"
+    assert "9 月 11 日" in result["message"]
+    # No baseline was written and the platform stays held, re-anchored.
+    assert "boss" not in freshness.load_baselines()["platforms"]
+    workflow = rounds_mod.round_status()
+    assert workflow["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
+    record = workflow["platforms"]["boss"]["resume_freshness"]
+    assert record["revision"]["resume_revision_id"] == "rev-9"
+    assert record["interaction_id"] != interaction_id
+    # Answering the re-anchored id against the same revision resolves.
+    result = freshness.respond(record["interaction_id"], choice="synced")
+    assert result["ok"] is True
+    assert freshness.load_baselines()["platforms"]["boss"]["resume_revision_id"] == "rev-9"
+
+
+def test_hold_respond_material_unavailable_keeps_hold(fresh_env, monkeypatch):
+    from jobagent.infra.cloud_client import CloudError
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture())
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+
+    def unavailable(binding_id):
+        raise CloudError("network down", status=503, code="upstream_unavailable", retryable=True)
+
+    monkeypatch.setattr(freshness.cloud_client, "resume_binding_material", unavailable)
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "resume_freshness_recheck_unavailable"
+    assert rounds_mod.round_status()["platforms"]["boss"]["status"] == rounds_mod.FRESHNESS_HOLD_STATUS
+
+
+def test_hold_respond_preparation_required_unwinds_binding(fresh_env, monkeypatch):
+    from jobagent.infra.cloud_client import CloudError
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_round")
+
+    def changed(binding_id):
+        raise CloudError("preparation required", status=409, code="preparation_required")
+
+    monkeypatch.setattr(freshness.cloud_client, "resume_binding_material", changed)
+    result = freshness.respond(interaction_id, choice="synced")
+    assert result["ok"] is False and result["error"] == "resume_binding_paused"
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert not active.get("resume_binding")
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert "resume_freshness_round_hold" not in active
+
+
+def test_invalid_choice_is_rejected_with_card(fresh_env):
+    write_round(binding_fixture())
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    result = freshness.respond(card["interaction"]["interaction_id"], choice="confirm_all")
+    assert result["ok"] is False and result["error"] == "invalid_interaction_response"
+    assert load_pending_interaction() is not None
+
+
+# ------------------------------------------------- scope and isolation
+
+
+def test_multi_platform_gates_are_independent(fresh_env):
+    write_round(binding_fixture())
+    set_baseline("boss")
+    assert freshness.gate_delivery("boss", source=source_fixture()) is None
+    card = freshness.gate_delivery("liepin", source=source_fixture())
+    assert card is not None and "猎聘" in card["interaction"]["prompt"]
+
+
+def test_baseline_file_is_account_owned(fresh_env):
+    from jobagent.infra.account_state import _ACCOUNT_OWNED_PATHS
+
+    assert "resume_freshness_baselines.json" in _ACCOUNT_OWNED_PATHS
+
+
+def test_round_skip_is_the_hold_escape_hatch(fresh_env):
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_round")
+    # The CLI round-skip path: clear the hold, then mark the platform skipped.
+    freshness.clear_hold("boss")
+    rounds_mod.set_platform_status("boss", "skipped_this_round", command="jobagent round skip")
+    active = state_mod.load_json(state_mod.current_round_path())
+    assert "resume_freshness" not in active["platforms"]["boss"]
+    assert "resume_freshness_round_hold" not in active
+    rounds_mod.assert_platform_turn("liepin")
+
+
+# ------------------------------------------------------- wiring points
+
+
+def test_native_start_delivery_consults_gate(fresh_env, monkeypatch):
+    from jobagent.application import delivery as delivery_mod
+    from jobagent.application import native_work
+
+    active = write_round(binding_fixture())
+    sentinel = {"ok": False, "error": "interaction_required", "sentinel": True}
+    called = {}
+
+    def fake_gate(platform, *, source, dry_run=False):
+        called["args"] = (platform, dict(source), dry_run)
+        return sentinel
+
+    monkeypatch.setattr(freshness, "gate_delivery", fake_gate)
+    monkeypatch.setattr(delivery_mod, "_load_reviewed", lambda *a, **k: {
+        "source_path": "/tmp/reviewed.json", "discover_id": "d-1",
+        "send_candidates": [{"id": "job-1", "title": "t", "company": "c", "url": "https://x.test/j"}],
+    })
+    monkeypatch.setattr(native_work, "current_account_ref", lambda: "acct_fresh")
+    monkeypatch.setattr(native_work.rounds, "assert_platform_turn", lambda platform: {})
+    monkeypatch.setattr(native_work.rounds, "ensure_current_round", lambda: active)
+    monkeypatch.setattr(native_work.rounds, "save_round", lambda value: None)
+    result = native_work.start_delivery("boss", input_path=None, preview_id="preview-1",
+                                        authorization_id="auth-1")
+    assert result == sentinel
+    assert called["args"][0] == "boss"
+    assert called["args"][1]["preview_id"] == "preview-1"
+    assert called["args"][2] is False
+    # The delivery was never staged on the platform.
+    assert "native_delivery" not in active["platforms"]["boss"]
+
+
+def test_native_start_delivery_dry_run_skips_gate(fresh_env, monkeypatch):
+    from jobagent.application import delivery as delivery_mod
+    from jobagent.application import native_work
+
+    active = write_round(binding_fixture())
+    monkeypatch.setattr(
+        freshness, "gate_delivery",
+        lambda *a, **k: pytest.fail("gate must not run for dry runs"),
+    )
+    monkeypatch.setattr(delivery_mod, "_load_reviewed", lambda *a, **k: {
+        "source_path": "/tmp/reviewed.json", "discover_id": "d-1", "send_candidates": [],
+    })
+    monkeypatch.setattr(native_work, "current_account_ref", lambda: "acct_fresh")
+    monkeypatch.setattr(native_work.rounds, "assert_platform_turn", lambda platform: {})
+    monkeypatch.setattr(native_work.rounds, "ensure_current_round", lambda: active)
+    monkeypatch.setattr(native_work.rounds, "save_round", lambda value: None)
+    result = native_work.start_delivery("boss", input_path=None, preview_id="preview-1",
+                                        authorization_id="auth-1", dry_run=True)
+    assert result["dry_run"] is True
+
+
+def test_legacy_send_reviewed_consults_gate(fresh_env, monkeypatch):
+    from jobagent.application import delivery
+
+    write_round(binding_fixture())
+    envelope = {
+        "platform": "liepin",
+        "discover_id": "d-1",
+        "source_path": "/tmp/reviewed.json",
+        "send_candidates": [{"id": "job-1", "title": "t", "company": "c", "url": "https://x.test/j"}],
+    }
+    sentinel = {"ok": False, "error": "interaction_required", "sentinel": True}
+    monkeypatch.setattr(freshness, "gate_delivery", lambda *a, **k: sentinel)
+    monkeypatch.setattr(delivery, "_load_reviewed", lambda *a, **k: envelope)
+    assert delivery.send_reviewed("liepin", input_path=None, preview_id="p-1",
+                                  authorization_id="a-1") == sentinel
+
+
+def test_next_work_with_everything_held_returns_respond_pointer(fresh_env, monkeypatch):
+    from jobagent.application import native_work
+
+    platforms = {
+        "boss": {"status": "reviewed"},
+        "liepin": {"status": "completed"},
+        "zhilian": {"status": "completed"},
+        "51job": {"status": "completed"},
+    }
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    interaction_id = card["interaction"]["interaction_id"]
+    freshness.respond(interaction_id, choice="pause_platform")
+    result = native_work.next_work()
+    assert result["ok"] is True and result["requires_user_action"] is True
+    assert interaction_id in result["next_suggested"]
+
+
+def test_cli_interaction_respond_dispatches_freshness(fresh_env):
+    from jobagent.cli import _dispatch, build_parser
+
+    platforms = {p: {"status": "pending"} for p in PLATFORMS}
+    platforms["boss"] = {"status": "reviewed"}
+    write_round(binding_fixture(), platforms=platforms)
+    card = freshness.gate_delivery("boss", source=source_fixture())
+    parser = build_parser()
+    args = parser.parse_args([
+        "interaction", "respond",
+        "--interaction-id", card["interaction"]["interaction_id"],
+        "--choice", "synced",
+    ])
+    result = _dispatch(args)
+    assert result["ok"] is True and result["event"] == "resume_freshness_synced"
+    assert freshness.load_baselines()["platforms"]["boss"]["resume_revision_id"] == "rev-1"


### PR DESCRIPTION
## 概要

0.6.7 同批发布的客户端侧（Part B）：**投递前平台简历新鲜度门禁**。

四平台投递 = 浏览器触发平台自有动作，平台发的是**用户存在该平台后台**的简历；工作台档案只进分析、永不外发。用户在工作台改了简历却忘了上传平台后台 → agent 照常触发投递 → 平台发旧简历，用户全程不知情。

### 行为

- 触发前比较：本轮绑定简历快照（revision id + content_digest）vs 该平台**上次投递基线**（`resume_freshness_baselines.json`，已列入 `_ACCOUNT_OWNED_PATHS`）
- 一致 / 无绑定轮 / dry-run → **静默直投**；无基线（首投）或修订变更 → 一次三选项卡（日期锚点）：
  - **已同步** → 更新基线 + 恢复投递指令
  - **挂起本平台** → 仅该平台挂起（`resume_freshness_hold`，不参与 current_platform 选择），其余平台继续
  - **整轮挂起** → `assert_platform_turn` 全轮拦截，应答后按原顺序续跑
- 挂起应答按 interaction id 从轮状态匹配（单 pending 槽被其他平台卡占用也能答）；释放时 `resume_binding_material` 复查：同修订 → 验证+基线；`preparation_required`/404 → discover 同型 unwind（改绑后保留新绑定）；网络错误 → 保留挂起可重试
- `round skip` 是逃生口（awaiting 卡与挂起一并清除）；基线只在已验证的同步声明后写入

### 挂载点

`native_work.start_delivery`（native 主路径，存 `native_delivery` 之前）+ `delivery.send_reviewed`（legacy 路径）+ `cli` interaction respond 分发 / round skip 清理。

## 对抗评审（26 agents，修正已全落地）

re-anchor 死分支删除（binding = 冻结快照，改版走 409 unwind）、404 同 unwind、unwind 绑定 id 守卫、单槽他卡保护、skip 清 awaiting 卡 + terminal 防御、挂起中非 synced 应答前置拒绝、`--continue-on-failure` 保留。详见 job-agent-server 仓 `docs/plans/2026-09-12-material-fallback-and-freshness-gate.md` B6。

## 测试

- `tests/test_resume_freshness.py`：**31 个**（检测正反例 / 三选项 / 挂起应答三分支 / 多平台独立 / 账号隔离 / skip 逃生口 + CLI 分发 / 评审修正全部 pin）
- 全量：**1074 passed**

## 关联

- 服务端同批：jiyangnan/job-agent-server#43（Part A material() 回退 + 设计文档）